### PR TITLE
Fix for JS editor extension example

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,22 @@
+{
+    "parserOptions": {
+        "ecmaVersion": 5,
+        "sourceType": "module"
+    },
+    "rules": {
+        "semi": 2,
+        "comma-dangle": 2,
+        "no-dupe-keys": 2,
+        "no-extra-semi": 2,
+        "no-unreachable": 2,
+        "no-undef": 2
+    },
+    "globals": {
+        "Atomic": true,
+        "ToolCore": true,
+        "Editor": true
+    },
+    "env": {
+        "node": true
+    }
+}

--- a/EditorPluginExample/Resources/EditorData/JSExample.plugin.js
+++ b/EditorPluginExample/Resources/EditorData/JSExample.plugin.js
@@ -70,14 +70,14 @@ function getNormalizedPath(path) {
     return path.substring(path.toLowerCase().indexOf(RESOURCES_MARKER));
 }
 
-var CustomEditorBuilder = { }
+var CustomEditorBuilder = { };
 
 /**
  * Returns true if this builder can generate an editor for this resource type
  */
 CustomEditorBuilder.canHandleResource = function(resourcePath) {
     return resourcePath.indexOf("custom.editorjs.json") > 0;
-}
+};
 
 /**
  * Generates a resource editor for the provided resource type
@@ -106,11 +106,12 @@ CustomEditorBuilder.getEditor = function(resourceFrame, resourcePath, tabContain
     });
 
     editor.subscribeToEvent("UserPreferencesChangedNotification", function(data) {
+        var webClient = editor.webView.webClient;
         webClient.executeJavaScript('HOST_preferencesChanged();');
     });
 
     return editor;
-}
+};
 
 
 
@@ -189,7 +190,7 @@ JSExamplePlugin.hierarchyContextItemClicked = function(node, refid) {
     }
 
     return false;
-}
+};
 
 JSExamplePlugin.projectContextItemClicked = function(asset, refid) {
     console.log("JSExamplePluginService.projectContextItemClicked: " + asset.name + " " + refid);
@@ -202,7 +203,7 @@ JSExamplePlugin.projectContextItemClicked = function(asset, refid) {
     }
 
     return false;
-}
+};
 
 
 module.exports = JSExamplePlugin;


### PR DESCRIPTION
fixes a syntax error I missed in the JS extension example that I missed.  I also went ahead and added a .eslintrc file at the root of the examples project which will allow ESLint to detect some of these issues ahead of time.  I've been bit by this one too many times.