### PR TITLE
Fix lint errors in the examples

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+**/gl-matrix.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,17 +4,20 @@
         "sourceType": "module"
     },
     "rules": {
-        "semi": 2,
+        "semi": 1,
         "comma-dangle": 2,
         "no-dupe-keys": 2,
-        "no-extra-semi": 2,
-        "no-unreachable": 2,
+        "no-extra-semi": 1,
+        "no-unreachable": 1,
         "no-undef": 2
     },
     "globals": {
         "Atomic": true,
         "ToolCore": true,
-        "Editor": true
+        "Editor": true,
+        "WebView": true,
+        "print": true,
+        "assert": true
     },
     "env": {
         "node": true

--- a/AtomicWebView/Resources/Components/WebView.js
+++ b/AtomicWebView/Resources/Components/WebView.js
@@ -47,7 +47,7 @@ exports.component = function(self) {
     // set the current page to the created page (ignoring the new tab dummy page)
     tabContainer.currentPage = tabContainer.numPages - 2;
     return true;
-  }
+  };
 
   newTabContent = new Atomic.UIWidget();
 
@@ -67,7 +67,7 @@ exports.component = function(self) {
   view.addChild(window);
   window.center();
 
-}
+};
 
 function createBookmarks(webView, layout,  bookmarks) {
 
@@ -93,7 +93,7 @@ function createBookmarks(webView, layout,  bookmarks) {
     var webClient = webView.webClient;
     (function() {
       var url = bookmarks[text];
-      button.onClick = function() { webClient.loadURL(url); }
+      button.onClick = function() { webClient.loadURL(url); };
     })();
   }
 }
@@ -176,14 +176,14 @@ function createBrowserTab(tabContainer, url) {
   fwdButton.disable();
 
   // go home
-  homeButton.onClick = function() { webClient.loadURL(home)};
+  homeButton.onClick = function() { webClient.loadURL(home);};
 
   // reload
   reloadButton.onClick = function() { webClient.reload(); };
 
   // Forward/Back
-  fwdButton.onClick = function() { webClient.goForward(); }
-  backButton.onClick = function() { webClient.goBack(); }
+  fwdButton.onClick = function() { webClient.goForward(); };
+  backButton.onClick = function() { webClient.goBack(); };
 
   // events
 

--- a/Basic2D/Resources/Components/Spinner.js
+++ b/Basic2D/Resources/Components/Spinner.js
@@ -2,7 +2,7 @@
 //inspector fields to make speed variable visible in editor
 var inspectorFields = {
     speed: 1.0
-}
+};
 
 exports.component = function(self) {
     
@@ -11,6 +11,6 @@ exports.component = function(self) {
         //roll a node
         self.node.roll(timeStep * 100);
 
-    }
+    };
 
-}
+};

--- a/Basic3D/Resources/Components/Spinner.js
+++ b/Basic3D/Resources/Components/Spinner.js
@@ -5,7 +5,7 @@ var inspectorFields = {
     //value speed will be able to be edited from editor
     //default value sets to the 1.0, so speed has a number type
     speed: 1.0
-}
+};
 
 exports.component = function(self) {
 
@@ -14,6 +14,6 @@ exports.component = function(self) {
         //rotate node around Y axis
         self.node.yaw(timeStep * 75 * self.speed);
 
-    }
+    };
 
-}
+};

--- a/Breakout/Resources/Components/Background.js
+++ b/Breakout/Resources/Components/Background.js
@@ -30,5 +30,5 @@ exports.component = function(self) {
             //load a sprite2D
             star.sprite = Atomic.cache.getResource("Sprite2D", "Sprites/star.png");
         }
-    }
-}
+    };
+};

--- a/Breakout/Resources/Components/Ball.js
+++ b/Breakout/Resources/Components/Ball.js
@@ -28,7 +28,7 @@ exports.component = function(self) {
             }
         });
         self.zoom = self.node.scene.getMainCamera().zoom;
-    }
+    };
 
     self.update = function(delta) {
         if (!self.started) return;
@@ -53,5 +53,5 @@ exports.component = function(self) {
             self.remove();
             self.sendEvent("CreateNewBall");
         }
-    }
-}
+    };
+};

--- a/Breakout/Resources/Components/Paddle.js
+++ b/Breakout/Resources/Components/Paddle.js
@@ -2,7 +2,7 @@
 
 var inspectorFields = {
     keyboard: false
-}
+};
 
 var PADDLE_SPEED = 0.03;
 
@@ -29,7 +29,7 @@ exports.component = function(self) {
 
         self.zoom = self.node.scene.getMainCamera().zoom;
         self.node.position2D = [self.node.position2D[0], -Atomic.graphics.height/2.5*Atomic.PIXEL_SIZE/self.zoom];
-    }
+    };
     self.createStartBall = function() {
         //create startBall prefab
         self.startBall = self.scene.createChildPrefab("Ball", "Prefabs/Ball.prefab");
@@ -37,7 +37,7 @@ exports.component = function(self) {
         self.startBall.position2D = [-100, -100];
         //also get a Ball component
         self.startBallComponent = self.startBall.getJSComponent("Ball");
-    }
+    };
 
     self.runBall = function() {
         //get rigidBody component of ours ball
@@ -46,7 +46,7 @@ exports.component = function(self) {
         body.applyForceToCenter([20/self.zoom + Math.random(), 20/self.zoom + Math.random()], true);
         self.startBallComponent.started = true;
         self.started = true;
-    }
+    };
 
     self.update = function(delta) {
         //if we haven't ball started
@@ -97,5 +97,5 @@ exports.component = function(self) {
         if(self.node.position2D[0] > Atomic.graphics.width / 2*Atomic.PIXEL_SIZE/self.zoom) {
             self.node.position2D = [Atomic.graphics.width / 2*Atomic.PIXEL_SIZE/self.zoom, -Atomic.graphics.height/2.5*Atomic.PIXEL_SIZE/self.zoom];
         }
-    }
-}
+    };
+};

--- a/Breakout/Resources/Components/PhysicsDebug.js
+++ b/Breakout/Resources/Components/PhysicsDebug.js
@@ -10,5 +10,5 @@ exports.component = function(self) {
         self.subscribeToEvent("PostRenderUpdate",function(_) {
             world.drawDebugGeometry();
         });
-    }
-}
+    };
+};

--- a/Breakout/Resources/Components/ScoreManager.js
+++ b/Breakout/Resources/Components/ScoreManager.js
@@ -40,9 +40,9 @@ exports.component = function(self) {
         layout.addChild(self.scoreText);
 
         self.updateText();
-    }
+    };
 
     self.updateText = function() {
         self.scoreText.text = "Score: " + self.scores;
-    }
-}
+    };
+};

--- a/Breakout/Resources/Components/Wall.js
+++ b/Breakout/Resources/Components/Wall.js
@@ -19,5 +19,5 @@ exports.component = function(self) {
         chain.setVertex(1, [-halfWidth, halfHeight]);
         chain.setVertex(2, [halfWidth, halfHeight]);
         chain.setVertex(3, [halfWidth, -halfHeight]);
-    }
-}
+    };
+};

--- a/BunnyMark/Resources/Scripts/main.js
+++ b/BunnyMark/Resources/Scripts/main.js
@@ -81,7 +81,7 @@ exports.update = function() {
                 scale[0] = scale[1] = (0.5 + Math.random() * 0.5);
                 bunny.scale2D = scale;
 
-                bunny.rotation2D = (Math.random() - 0.5)
+                bunny.rotation2D = (Math.random() - 0.5);
                 count++;
             }
         }
@@ -136,7 +136,7 @@ exports.update = function() {
 
     }
 
-}
+};
 
 createInstructions();
 
@@ -171,4 +171,3 @@ function createInstructions() {
   layout.addChild(scoreText);
   }
 
-;

--- a/Butterflies/Resources/Components/Butterfly.js
+++ b/Butterflies/Resources/Components/Butterfly.js
@@ -24,7 +24,7 @@ exports.component = function(self) {
         self.spr.setAnimation("idle");
         self.spr.color = [.1 + Math.random() * .9, .1 + Math.random() * .9, .1 + Math.random() * .9, 1];
         self.spr.blendMode = Atomic.BLEND_ALPHA;
-    }
+    };
 
     self.update = function(timeStep) {
 
@@ -38,7 +38,7 @@ exports.component = function(self) {
         //check if our butterfly is out of bounds
         if (self.pos[0] < -halfWidth || self.pos[1] < -halfHeight || self.pos[0] > halfWidth || self.pos[1] > halfHeight)
             node.remove();
-    }
+    };
     //just a maths functions, nothing really interesting
     self.circWrapTo = function(value, target, step) {
         if (value == target) return target;
@@ -67,4 +67,4 @@ exports.component = function(self) {
     };
 
 
-}
+};

--- a/Butterflies/Resources/Components/Spawner.js
+++ b/Butterflies/Resources/Components/Spawner.js
@@ -17,7 +17,7 @@ exports.component = function(self) {
                 createButterflyParticle([event.centerX, event.centerY]);
             }
         });
-    }
+    };
 
     self.update = function(timeStep) {
         //if Left mouse button is pressed
@@ -29,7 +29,7 @@ exports.component = function(self) {
             var mousePos = Atomic.input.getMousePosition();
             createButterflyParticle(mousePos);
         }
-    }
+    };
 
     function createButterflyNode(pos) {
       //project mouse screen position to the world position
@@ -49,4 +49,4 @@ exports.component = function(self) {
       var pex = emitter.createComponent("ParticleEmitter2D");
       pex.effect = particleEffect;
     }
-}
+};

--- a/CharacterAnimation2D/Resources/Components/Imp.js
+++ b/CharacterAnimation2D/Resources/Components/Imp.js
@@ -28,4 +28,4 @@ exports.component = function(self) {
         animatedSprite.setAnimation("dead");
     });
 
-}
+};

--- a/CharacterAnimation2D/Resources/Components/UI.js
+++ b/CharacterAnimation2D/Resources/Components/UI.js
@@ -18,7 +18,7 @@ function createButton(self, text, event, layout) {
 
         self.sendEvent(event);
 
-    }
+    };
     //add button
     layout.addChild(button);
 
@@ -44,4 +44,4 @@ exports.component = function(self) {
     createButton(self, "Play Hit", "PlayHit", layout);
     createButton(self, "Play Dead", "PlayDead", layout);
 
-}
+};

--- a/CharacterAnimation3D/Resources/Components/Roboman.js
+++ b/CharacterAnimation3D/Resources/Components/Roboman.js
@@ -29,6 +29,6 @@ exports.component = function(self) {
         //rotate ours node around Y axis
         node.yaw(timeStep * 10);
 
-    }
+    };
 
-}
+};

--- a/CharacterAnimation3D/Resources/Components/UI.js
+++ b/CharacterAnimation3D/Resources/Components/UI.js
@@ -18,7 +18,7 @@ function createButton(self, text, event, layout) {
 
         self.sendEvent(event);
 
-    }
+    };
     //add button
     layout.addChild(button);
 
@@ -44,4 +44,4 @@ exports.component = function(self) {
     createButton(self, "Play Run", "PlayRun", layout);
     createButton(self, "Play Attack", "PlayAttack", layout);
 
-}
+};

--- a/Chickens/Resources/Components/Input.js
+++ b/Chickens/Resources/Components/Input.js
@@ -16,7 +16,7 @@ var component = function(self) {
 
         Atomic.audio.listener = node.getComponent("SoundListener");
 
-    }
+    };
 
     //update function called once per each frame
     self.update = function(timeStep) {
@@ -47,9 +47,9 @@ var component = function(self) {
             node.translate([-MOVE_SPEED * timeStep, 0, 0]);
 
 
-    }
+    };
 
-}
+};
 
 //Math function to get Quaternion from Euler angles
 function QuatFromEuler(x, y, z) {

--- a/Chickens/Resources/Components/Player.js
+++ b/Chickens/Resources/Components/Player.js
@@ -35,8 +35,8 @@ var component = function(self) {
         if (pos[0] < -20 || pos[0] > 20 || pos[2] < -20 || pos[2] > 20)
             node.yaw(MODEL_ROTATE_SPEED * timeStep);
 
-    }
+    };
 
-}
+};
 
 exports.component = component;

--- a/CubeMapExample/Resources/Components/Spinner.js
+++ b/CubeMapExample/Resources/Components/Spinner.js
@@ -3,7 +3,7 @@
 
 var inspectorFields = {
   speed: 1.0
-}
+};
 
 exports.component = function(self) {
 
@@ -12,6 +12,6 @@ exports.component = function(self) {
     self.node.yaw(timeStep * 75 * self.speed);
     self.node.roll(timeStep * 25 * self.speed);
     self.node.pitch(timeStep * 15 * self.speed);
-  }
+  };
 
-}
+};

--- a/CustomGeometry/Resources/Components/Spinner.js
+++ b/CustomGeometry/Resources/Components/Spinner.js
@@ -5,5 +5,5 @@ exports.component = function(self) {
     self.update = function(timeStep) {
         //Roll the node
         self.node.roll(timeStep * 75);
-  }
-}
+  };
+};

--- a/CustomGeometry/Resources/Components/Triangle.js
+++ b/CustomGeometry/Resources/Components/Triangle.js
@@ -24,5 +24,5 @@ exports.component = function(self) {
 
         //Save changes
         customGeometry.commit();
-    }
-}
+    };
+};

--- a/EventLoop/Resources/Components/Star.js
+++ b/EventLoop/Resources/Components/Star.js
@@ -4,7 +4,7 @@ module.exports.component = function (self) {
 
     // Inspector fields will show up in the Atomic Editor scene view to allow editing
     var inspectorFields = {
-        speed: 100,
+        speed: 100
     };
     //link to the current node
     var node = self.node;

--- a/FileExample/Resources.asset
+++ b/FileExample/Resources.asset
@@ -1,0 +1,5 @@
+{
+	"version": 1,
+	"guid": "ad4e2c0c05401eabe24ce1294eca8106",
+	"FolderImporter": {}
+}

--- a/FileExample/Resources/Scripts.asset
+++ b/FileExample/Resources/Scripts.asset
@@ -1,0 +1,5 @@
+{
+	"version": 1,
+	"guid": "2aba3aa43bdca13c2d431ad7a7fd7de0",
+	"FolderImporter": {}
+}

--- a/FileExample/Resources/Scripts/main.js
+++ b/FileExample/Resources/Scripts/main.js
@@ -10,7 +10,7 @@ var documentsDir = filesystem.getUserDocumentsDir();
 var mydata = {
 	name: "Josh",
 	lifeTheUniverseAndEverything: 42
-}
+};
 
 // Open a file in write mode
 var file = new Atomic.File(documentsDir + "AtomicGameEngineTest.json", Atomic.FILE_WRITE);

--- a/FileExample/Resources/Scripts/main.js.asset
+++ b/FileExample/Resources/Scripts/main.js.asset
@@ -1,0 +1,7 @@
+{
+	"version": 1,
+	"guid": "2cb95bf49afafd869ccbe3fab3f11467",
+	"JavascriptImporter": {
+		"IsComponentFile": false
+	}
+}

--- a/Light2DExample/Resources/Components/Background.js
+++ b/Light2DExample/Resources/Components/Background.js
@@ -21,4 +21,4 @@ exports.component = function(self) {
     //scale the current node with X and Y
     node.scale2D = [viewWidth / width, viewHeight / height];
 
-}
+};

--- a/Light2DExample/Resources/Components/Light.js
+++ b/Light2DExample/Resources/Components/Light.js
@@ -39,6 +39,6 @@ exports.component = function(self) {
             movey = -movey;
         }
 
-    }
+    };
 
-}
+};

--- a/Light2DExample/Resources/Components/ShadowCaster.js
+++ b/Light2DExample/Resources/Components/ShadowCaster.js
@@ -31,4 +31,4 @@ exports.component = function(self) {
     //Set position of the current node in 2D space
     node.position2D = [x, y];
 
-}
+};

--- a/MultiScript/Resources/Components/InstantiatedSpinner.js
+++ b/MultiScript/Resources/Components/InstantiatedSpinner.js
@@ -5,7 +5,7 @@
 
 var inspectorFields = {
   speed: 1.0
-}
+};
 
 exports.component = function(self) {
 
@@ -13,6 +13,6 @@ exports.component = function(self) {
 
     self.instantated = self.node.createJSComponent("Components/ProtoSpinner.js", { speed: self.speed } );
 
-  }
+  };
 
-}
+};

--- a/MultiScript/Resources/Components/ProtoSpinner.js
+++ b/MultiScript/Resources/Components/ProtoSpinner.js
@@ -5,7 +5,7 @@
 
 var inspectorFields = {
   speed: 1.0
-}
+};
 
 function ProtoSpinner() {
 
@@ -20,6 +20,6 @@ ProtoSpinner.prototype.update = function(timeStep) {
 
   this.node.yaw(timeStep * 75 * this.speed);
 
-}
+};
 
-module.exports = ProtoSpinner
+module.exports = ProtoSpinner;

--- a/MultiScript/Resources/Components/Spinner.js
+++ b/MultiScript/Resources/Components/Spinner.js
@@ -5,7 +5,7 @@
 
 var inspectorFields = {
   speed: 1.0
-}
+};
 
 exports.component = function(self) {
 
@@ -13,6 +13,6 @@ exports.component = function(self) {
 
     self.node.yaw(timeStep * 75 * self.speed);
 
-  }
+  };
 
-}
+};

--- a/NativePluginExample/Resources/Components/Star.js
+++ b/NativePluginExample/Resources/Components/Star.js
@@ -1,16 +1,20 @@
-var game = Atomic.game;
-var node = self.node;
+'atomic component';
 
-function start() {
+module.exports.component = function (self) {
 
-	var sprite2D = node.createComponent("StaticSprite2D");
-	sprite2D.sprite = game.getSprite2D("Sprites/star.png");
-	sprite2D.blendMode = Atomic.BLEND_ALPHA;
-	
-}
+    //link to the current node
+    var node = self.node;
 
-function update(timeStep) {	
-	
-	node.roll(timeStep * 100);
+    // Start will be called when component is instantiated
+    self.start = function () {
+        //create a new sprite
+        var sprite2D = node.createComponent("StaticSprite2D");
+        sprite2D.sprite = Atomic.cache.getResource("Sprite2D", "Sprites/star.png");
+        sprite2D.blendMode = Atomic.BLEND_ALPHA;
+    };
 
-}
+    // Update will be called every cycle
+    self.update = function (timeStep) {
+        node.roll(timeStep * 100);
+    };
+};

--- a/ParticleEmitter3D/Resources/Components/UI.js
+++ b/ParticleEmitter3D/Resources/Components/UI.js
@@ -20,7 +20,7 @@ function createButton(self, text, peffectName, layout) {
 
         particleEmitter.effect = Atomic.cache.getResource("ParticleEffect", "Particles/" + peffectName + ".peffect");
 
-    }
+    };
     //add button
     layout.addChild(button);
 
@@ -28,7 +28,7 @@ function createButton(self, text, peffectName, layout) {
 //UI component
 exports.component = function(self) {
 
-    particleEmitter = self.getComponent("ParticleEmitter")
+    particleEmitter = self.getComponent("ParticleEmitter");
 
     // root view
     self.uiView = new Atomic.UIView();
@@ -49,4 +49,4 @@ exports.component = function(self) {
     createButton(self, "SmokeStack", "SmokeStack", layout);
     createButton(self, "SnowExplosion", "SnowExplosion", layout);
 
-}
+};

--- a/Particles2D/Resources/Components/ParticleSystem.js
+++ b/Particles2D/Resources/Components/ParticleSystem.js
@@ -18,4 +18,4 @@ exports.component = function(self) {
         emitter.effect = Atomic.cache.getResource("ParticleEffect2D", "Particles/snow.pex");
     });
 
-}
+};

--- a/Particles2D/Resources/Components/UI.js
+++ b/Particles2D/Resources/Components/UI.js
@@ -18,7 +18,7 @@ function createButton(self, text, event, layout) {
 
         self.sendEvent(event);
 
-    }
+    };
     //add button
     layout.addChild(button);
 
@@ -43,4 +43,4 @@ exports.component = function(self) {
     createButton(self, "Play Snow", "PlaySnow", layout);
     createButton(self, "Play Spark", "PlaySpark", layout);
 
-}
+};

--- a/PhysicsPlatformer/Resources/Components/Background.js
+++ b/PhysicsPlatformer/Resources/Components/Background.js
@@ -18,8 +18,8 @@ var component = function(self) {
         var zoom = 4.0 - camera.zoom;
         //scale2D is an array with two elements, the first is x, the second is y
         self.node.scale2D = [zoom , zoom];
-    }
+    };
 
-}
+};
 
 exports.component = component;

--- a/PhysicsPlatformer/Resources/Components/Bat.js
+++ b/PhysicsPlatformer/Resources/Components/Bat.js
@@ -10,7 +10,7 @@ var component = function (self) {
   var node = self.node;
 
   //get a component from our current node
-  var sprite = node.getComponent("AnimatedSprite2D")
+  var sprite = node.getComponent("AnimatedSprite2D");
   sprite.setAnimation("Fly");
 
   var cwaypoint = -1;
@@ -25,7 +25,7 @@ var component = function (self) {
       light.color = [1, 0.1, 0.8, .85];
       light.radius = 1;
     }
-  }
+  };
 
   self.update = function(timestep) {
 
@@ -56,8 +56,8 @@ var component = function (self) {
       //set position of our node
       node.position2D = pos;
 
-  }
+  };
 
-}
+};
 
 exports.component = component;

--- a/PhysicsPlatformer/Resources/Components/Coin.js
+++ b/PhysicsPlatformer/Resources/Components/Coin.js
@@ -10,7 +10,7 @@ var inspectorFields = {
   pickupSound: ["Sound", "Sounds/Pickup_Coin8.ogg"],
   bounceSound: ["Sound"]
 
-}
+};
 
 //A Coin
 var component = function(self) {
@@ -22,7 +22,7 @@ var component = function(self) {
 
   // Resources
   //getting AnimatedSprite2D component
-  var sprite = node.getComponent("AnimatedSprite2D")
+  var sprite = node.getComponent("AnimatedSprite2D");
   sprite.setAnimation("idle");
   //getting SoundSource component
   var soundSource = node.getComponent("SoundSource");
@@ -41,7 +41,7 @@ var component = function(self) {
 
       node.createJSComponent("Components/LightFlicker.js");
     }
-  }
+  };
 
   self.update = function(timeStep) {
 
@@ -100,8 +100,8 @@ var component = function(self) {
 
     }
 
-  }
+  };
 
-}
+};
 
 exports.component = component;

--- a/PhysicsPlatformer/Resources/Components/DayTime.js
+++ b/PhysicsPlatformer/Resources/Components/DayTime.js
@@ -12,7 +12,7 @@ var component = function(self) {
       var sun = self.node.getChild("TheSun").getComponent("DirectionalLight2D");
       sun.enabled = false;
     }
-  }
-}
+  };
+};
 
 exports.component = component;

--- a/PhysicsPlatformer/Resources/Components/Level.js
+++ b/PhysicsPlatformer/Resources/Components/Level.js
@@ -74,8 +74,8 @@ var component = function (self) {
       self.scene.getChild("TheSun").getComponent("DirectionalLight2D").numRays = 512;
     }
 
-  }
+  };
 
-}
+};
 
 exports.component = component;

--- a/PhysicsPlatformer/Resources/Components/LightFlicker.js
+++ b/PhysicsPlatformer/Resources/Components/LightFlicker.js
@@ -1,4 +1,4 @@
-"atomic component"
+"atomic component";
 
 // a flickering light component
 exports.component = function(self){
@@ -33,5 +33,5 @@ exports.component = function(self){
 
     if (self.light.radius > targetValue)
       self.light.radius -= timestep * 10;
-  }
-}
+  };
+};

--- a/PhysicsPlatformer/Resources/Components/MovingPlatform.js
+++ b/PhysicsPlatformer/Resources/Components/MovingPlatform.js
@@ -56,7 +56,7 @@ self.update = function(timeStep) {
     //set velocity of our body(node) to the dir value
     body.setLinearVelocity(dir);
 
-}
-}
+};
+};
 
 exports.component = component;

--- a/PhysicsPlatformer/Resources/Components/Player.js
+++ b/PhysicsPlatformer/Resources/Components/Player.js
@@ -4,7 +4,7 @@ var inspectorFields = {
 
     jumpSound: ["Sound"]
 
-}
+};
 
 //A Player
 exports.component = function(self) {
@@ -77,7 +77,7 @@ exports.component = function(self) {
           light.radius = 4;
         }
 
-    }
+    };
 
     self.update = function(timeStep) {
         //handle our input and animation stuff
@@ -92,7 +92,7 @@ exports.component = function(self) {
                node.scale2D = [1, 1];
         }
 
-    }
+    };
 
     function setAnimation(animName) {
 
@@ -206,4 +206,4 @@ exports.component = function(self) {
 
     }
 
-}
+};

--- a/PhysicsPlatformer/Resources/Components/Vine.js
+++ b/PhysicsPlatformer/Resources/Components/Vine.js
@@ -73,8 +73,8 @@ self.start = function() {
         constraintRope.maxLength = (NUM_OBJECTS + 0.01);
 
 
-    }
+    };
 
-}
+};
 
 exports.component = component;

--- a/PhysicsPlatformer/Resources/Modules/DPad.js
+++ b/PhysicsPlatformer/Resources/Modules/DPad.js
@@ -51,7 +51,7 @@ function DPad() {
         //if we are using custom view, then just set dpad position
         this.dpad.setPosition(-width/3, height/4);
       }
-    }
+    };
     //adds horizontal and vertical buttons
     this.addAll = function() {
       //adds horizontal buttons
@@ -59,7 +59,7 @@ function DPad() {
       //adds vertical buttons
       this.addVertical();
 
-    }
+    };
     //adds horizontal buttons
     this.addHorizontal = function() {
       //if layout params doesn't exist create a new one
@@ -90,7 +90,7 @@ function DPad() {
       Atomic.input.bindButton(this.rightButton, Atomic.KEY_RIGHT);
       Atomic.input.bindButton(this.leftButton, Atomic.KEY_LEFT);
 
-    }
+    };
     //adds vertical buttons
     this.addVertical = function() {
       //if layout params doesn't exist create a new one
@@ -120,7 +120,7 @@ function DPad() {
       Atomic.input.bindButton(this.upButton, Atomic.KEY_UP);
       Atomic.input.bindButton(this.downButton, Atomic.KEY_DOWN);
 
-    }
+    };
 
     //inits layout prams for up/down buttons
     this.initUpDownLayoutParams = function() {
@@ -136,7 +136,7 @@ function DPad() {
       this.layoutParamsUpDown.maxWidth = verticButtonsSize[0]*6;
       this.layoutParamsUpDown.maxHeight = verticButtonsSize[1]*6;
 
-    }
+    };
 
     //inits layout params for left/right buttons
     this.initLeftRightLayoutParams = function() {
@@ -152,32 +152,32 @@ function DPad() {
       this.layoutParamsLeftRight.maxWidth = horizButtonsSize[0]*6;
       this.layoutParamsLeftRight.maxHeight = horizButtonsSize[1]*6;
 
-    }
+    };
 
     //set horizontal spacing
     this.setSpacingX = function(spacing) {
       dpadSpacingX = spacing;
       this.dpad.spacing = spacing;
-    }
+    };
 
     //set vertical spacing
     this.setSpacingY = function(spacing) {
       dpadSpacingY = spacing;
       this.upDownLayout.spacing = spacing;
-    }
+    };
 
     //set view position
     this.setPosition = function(x, y) {
       this.view.setPosition(x, y);
-    }
+    };
 
     this.updateViewSize = function() {
       this.view.setSize(horizButtonsSize[0]*4+verticButtonsSize[0]*2+dpadSpacingX, horizButtonsSize[1]*2+verticButtonsSize[1]*4+dpadSpacingY);
-    }
+    };
 
     this.remove = function() {
       this.view.removeChild(this.dpad);
-    }
+    };
 }
 
 module.exports = DPad;

--- a/PhysicsPlatformer/Resources/Modules/LevelParser.js
+++ b/PhysicsPlatformer/Resources/Modules/LevelParser.js
@@ -2,21 +2,21 @@
 //It's just a module, so it don't need atomic component string
 
 //Define a constructor
-LevelParser = function(tileMap) {
+var LevelParser = function(tileMap) {
 
     this.tileMap = tileMap;
 
     this.entities = [];
     this.parseEntities();
 
-}
+};
 //Define a prototype
 LevelParser.prototype = {
 
     //parsing our entities from tileMap object
     parseEntities: function() {
 
-        entityLayer = this.tileMap.getLayerByName("Entities");
+        var entityLayer = this.tileMap.getLayerByName("Entities");
 
         var platforms = {};
         //if layer Entities exists
@@ -88,7 +88,7 @@ LevelParser.prototype = {
                     type: "MovingPlatform",
                     start: platforms[pnum][0].position,
                     stop: platforms[pnum][1].position
-                }
+                };
 
                 this.entities.push(entity);
             }
@@ -133,7 +133,7 @@ LevelParser.prototype = {
 
     createPhysics: function(tileMap, tmxFile) {
         //get Physics layer
-        physicsLayer = tileMap.getLayerByName("Physics");
+        var physicsLayer = tileMap.getLayerByName("Physics");
 
         //if layer exists
         if (physicsLayer) {

--- a/PhysicsPlatformer/Resources/Scripts/main.js
+++ b/PhysicsPlatformer/Resources/Scripts/main.js
@@ -36,7 +36,7 @@ buttonDaytime.onClick = function () {
   run(true);
   //we need to return value here, otherwise we will be GC'ed
   return true;
-}
+};
 buttonLayout.addChild(buttonDaytime);
 
 var buttonNightTime = new Atomic.UIButton();
@@ -45,7 +45,7 @@ buttonNightTime.onClick = function () {
   run(false);
   //we need to return value here, otherwise we will be GC'ed
   return true;
-}
+};
 buttonLayout.addChild(buttonNightTime);
 
 window.resizeToFitContent();

--- a/RenderToTexture/Resources/Components/RenderToTexture.js
+++ b/RenderToTexture/Resources/Components/RenderToTexture.js
@@ -35,6 +35,6 @@ exports.component = function(self) {
       //set rttViewport as a main viewport in the surface
       surface.setViewport(0, rttViewport);
 
-    }
+    };
 
-}
+};

--- a/RenderToTexture/Resources/Components/Spinner.js
+++ b/RenderToTexture/Resources/Components/Spinner.js
@@ -2,7 +2,7 @@
 //inspector fields to make speed variable visible in editor
 var inspectorFields = {
     speed: 1.0
-}
+};
 
 exports.component = function(self) {
 
@@ -11,6 +11,6 @@ exports.component = function(self) {
         self.node.yaw(timeStep * 75 * self.speed);
         //rotate current node around X axis
         self.node.pitch(-timeStep * 25 * self.speed);
-    }
+    };
 
-}
+};

--- a/RoboMan3D/Resources/Components/AvatarController.js
+++ b/RoboMan3D/Resources/Components/AvatarController.js
@@ -10,7 +10,7 @@ var vec3 = glmatrix.vec3;
 var inspectorFields = {
   //needs default value to make editor understand type of that value
   speed: 1.0
-}
+};
 //define a component AvatarController
 exports.component = function(self) {
   //link to the current node
@@ -69,16 +69,17 @@ exports.component = function(self) {
     var shape = node.createComponent("CollisionShape");
     shape.setCapsule(2, 4, [0, 2, 0]);
 
-  }
+  };
 
   self.fixedUpdate = function(timestep) {
 
     //get a RigidBody component from the current node
     var body = node.getComponent("RigidBody");
+    var inAirTimer = 0.00;
 
     // Update the in air timer. Reset if grounded
     if (!onGround)
-    inAirTimer += timeStep;
+    inAirTimer += timestep;
     else
     inAirTimer = 0.0;
 
@@ -98,16 +99,16 @@ exports.component = function(self) {
 
     if (cameraMode != 2) {
       if (moveForward) {
-        vec3.add(moveDir, moveDir, [0, 0, 1])
+        vec3.add(moveDir, moveDir, [0, 0, 1]);
       }
       if (moveBackwards) {
-        vec3.add(moveDir, moveDir, [0, 0, -1])
+        vec3.add(moveDir, moveDir, [0, 0, -1]);
       }
       if (moveLeft) {
-        vec3.add(moveDir, moveDir, [-1, 0, 0])
+        vec3.add(moveDir, moveDir, [-1, 0, 0]);
       }
       if (moveRight) {
-        vec3.add(moveDir, moveDir, [1, 0, 0])
+        vec3.add(moveDir, moveDir, [1, 0, 0]);
       }
     }
 
@@ -153,7 +154,7 @@ exports.component = function(self) {
     // Reset grounded flag for next frame
     onGround = true;
 
-  }
+  };
 
   function MoveCamera(timeStep) {
 
@@ -178,13 +179,13 @@ exports.component = function(self) {
 
     //translate camera on the amount of speed value
     if (moveForward)
-      cameraNode.translate([0.0, 0.0, speed])
+      cameraNode.translate([0.0, 0.0, speed]);
     if (moveBackwards)
-      cameraNode.translate([0.0, 0.0, -speed])
+      cameraNode.translate([0.0, 0.0, -speed]);
     if (moveLeft)
-      cameraNode.translate([-speed, 0.0, 0.0])
+      cameraNode.translate([-speed, 0.0, 0.0]);
     if (moveRight)
-      cameraNode.translate([speed, 0.0, 0.0])
+      cameraNode.translate([speed, 0.0, 0.0]);
 
   }
 
@@ -262,7 +263,7 @@ exports.component = function(self) {
         cameraMode = 0;
     }
 
-  }
+  };
 
   //that function called right after update function
   self.postUpdate = function(timestep) {
@@ -271,7 +272,7 @@ exports.component = function(self) {
     var rot = node.getRotation();
 
     //create quaternion
-    dir = quat.create();
+    var dir = quat.create();
     //set X value
     quat.setAxisAngle(dir, [1, 0, 0], (pitch * Math.PI / 180.0));
 
@@ -314,8 +315,8 @@ exports.component = function(self) {
     else{
       MoveCamera(timestep);
     }
-  }
-}
+  };
+};
 
 function QuatFromEuler(x, y, z) {
     var M_PI = 3.14159265358979323846264338327950288;

--- a/RoboMan3D/Resources/Components/RoboMan.js
+++ b/RoboMan3D/Resources/Components/RoboMan.js
@@ -27,7 +27,7 @@ exports.component = function(self) {
     //rotate current node around Y axis
     node.yaw(180);
 
-  }
+  };
 
   self.update = function(timeStep) {
 
@@ -46,6 +46,6 @@ exports.component = function(self) {
 
     }
 
-  }
+  };
 
-}
+};

--- a/RoboMan3D/Resources/Modules/DPad.js
+++ b/RoboMan3D/Resources/Modules/DPad.js
@@ -51,7 +51,7 @@ function DPad() {
         //if we are using custom view, then just set dpad position
         this.dpad.setPosition(-width/3, height/4);
       }
-    }
+    };
     //adds horizontal and vertical buttons
     this.addAll = function() {
       //adds horizontal buttons
@@ -59,7 +59,7 @@ function DPad() {
       //adds vertical buttons
       this.addVertical();
 
-    }
+    };
     //adds horizontal buttons
     this.addHorizontal = function() {
       //if layout params doesn't exist create a new one
@@ -90,7 +90,7 @@ function DPad() {
       Atomic.input.bindButton(this.rightButton, Atomic.KEY_RIGHT);
       Atomic.input.bindButton(this.leftButton, Atomic.KEY_LEFT);
 
-    }
+    };
     //adds vertical buttons
     this.addVertical = function() {
       //if layout params doesn't exist create a new one
@@ -120,7 +120,7 @@ function DPad() {
       Atomic.input.bindButton(this.upButton, Atomic.KEY_UP);
       Atomic.input.bindButton(this.downButton, Atomic.KEY_DOWN);
 
-    }
+    };
 
     //inits layout prams for up/down buttons
     this.initUpDownLayoutParams = function() {
@@ -136,7 +136,7 @@ function DPad() {
       this.layoutParamsUpDown.maxWidth = verticButtonsSize[0]*6;
       this.layoutParamsUpDown.maxHeight = verticButtonsSize[1]*6;
 
-    }
+    };
 
     //inits layout params for left/right buttons
     this.initLeftRightLayoutParams = function() {
@@ -152,32 +152,32 @@ function DPad() {
       this.layoutParamsLeftRight.maxWidth = horizButtonsSize[0]*6;
       this.layoutParamsLeftRight.maxHeight = horizButtonsSize[1]*6;
 
-    }
+    };
 
     //set horizontal spacing
     this.setSpacingX = function(spacing) {
       dpadSpacingX = spacing;
       this.dpad.spacing = spacing;
-    }
+    };
 
     //set vertical spacing
     this.setSpacingY = function(spacing) {
       dpadSpacingY = spacing;
       this.upDownLayout.spacing = spacing;
-    }
+    };
 
     //set view position
     this.setPosition = function(x, y) {
       this.view.setPosition(x, y);
-    }
+    };
 
     this.updateViewSize = function() {
       this.view.setSize(horizButtonsSize[0]*4+verticButtonsSize[0]*2+dpadSpacingX, horizButtonsSize[1]*2+verticButtonsSize[1]*4+dpadSpacingY);
-    }
+    };
 
     this.remove = function() {
       this.view.removeChild(this.dpad);
-    }
+    };
 }
 
 module.exports = DPad;

--- a/Roboman3DTypeScript/Resources/Modules/DPad.js
+++ b/Roboman3DTypeScript/Resources/Modules/DPad.js
@@ -51,7 +51,7 @@ function DPad() {
         //if we are using custom view, then just set dpad position
         this.dpad.setPosition(-width/3, height/4);
       }
-    }
+    };
     //adds horizontal and vertical buttons
     this.addAll = function() {
       //adds horizontal buttons
@@ -59,7 +59,7 @@ function DPad() {
       //adds vertical buttons
       this.addVertical();
 
-    }
+    };
     //adds horizontal buttons
     this.addHorizontal = function() {
       //if layout params doesn't exist create a new one
@@ -90,7 +90,7 @@ function DPad() {
       Atomic.input.bindButton(this.rightButton, Atomic.KEY_RIGHT);
       Atomic.input.bindButton(this.leftButton, Atomic.KEY_LEFT);
 
-    }
+    };
     //adds vertical buttons
     this.addVertical = function() {
       //if layout params doesn't exist create a new one
@@ -120,7 +120,7 @@ function DPad() {
       Atomic.input.bindButton(this.upButton, Atomic.KEY_UP);
       Atomic.input.bindButton(this.downButton, Atomic.KEY_DOWN);
 
-    }
+    };
 
     //inits layout prams for up/down buttons
     this.initUpDownLayoutParams = function() {
@@ -136,7 +136,7 @@ function DPad() {
       this.layoutParamsUpDown.maxWidth = verticButtonsSize[0]*6;
       this.layoutParamsUpDown.maxHeight = verticButtonsSize[1]*6;
 
-    }
+    };
 
     //inits layout params for left/right buttons
     this.initLeftRightLayoutParams = function() {
@@ -152,32 +152,32 @@ function DPad() {
       this.layoutParamsLeftRight.maxWidth = horizButtonsSize[0]*6;
       this.layoutParamsLeftRight.maxHeight = horizButtonsSize[1]*6;
 
-    }
+    };
 
     //set horizontal spacing
     this.setSpacingX = function(spacing) {
       dpadSpacingX = spacing;
       this.dpad.spacing = spacing;
-    }
+    };
 
     //set vertical spacing
     this.setSpacingY = function(spacing) {
       dpadSpacingY = spacing;
       this.upDownLayout.spacing = spacing;
-    }
+    };
 
     //set view position
     this.setPosition = function(x, y) {
       this.view.setPosition(x, y);
-    }
+    };
 
     this.updateViewSize = function() {
       this.view.setSize(horizButtonsSize[0]*4+verticButtonsSize[0]*2+dpadSpacingX, horizButtonsSize[1]*2+verticButtonsSize[1]*4+dpadSpacingY);
-    }
+    };
 
     this.remove = function() {
       this.view.removeChild(this.dpad);
-    }
+    };
 }
 
 module.exports = DPad;

--- a/SpaceGame/Resources/Components/AI.js
+++ b/SpaceGame/Resources/Components/AI.js
@@ -1,3 +1,4 @@
+/* global SpaceGame */
 'atomic component';
 
 exports.component = function(self) {
@@ -12,7 +13,7 @@ exports.component = function(self) {
   self.start = function() {
 
 
-  }
+  };
 
   self.update = function(timeStep) {
 
@@ -56,6 +57,6 @@ exports.component = function(self) {
       SpaceGame.spawnBullet(pos, false);
     }
 
-  }
+  };
 
-}
+};

--- a/SpaceGame/Resources/Components/Bullet.js
+++ b/SpaceGame/Resources/Components/Bullet.js
@@ -1,3 +1,4 @@
+/* global SpaceGame */
 'atomic component';
 
 exports.component = function(self) {
@@ -32,7 +33,7 @@ exports.component = function(self) {
       node.roll(180);
     }
 
-  }
+  };
 
   function updateEnemyBullet() {
 
@@ -120,6 +121,6 @@ exports.component = function(self) {
       }
     }
 
-  }
+  };
 
-}
+};

--- a/SpaceGame/Resources/Components/CapitalShip.js
+++ b/SpaceGame/Resources/Components/CapitalShip.js
@@ -1,3 +1,4 @@
+/* global SpaceGame */
 'atomic component';
 
 exports.component = function(self) {
@@ -26,7 +27,7 @@ exports.component = function(self) {
       SpaceGame.win();
     }
 
-  }
+  };
 
   function die() {
 
@@ -66,7 +67,7 @@ exports.component = function(self) {
     node.position2D = [-4, SpaceGame.halfHeight - 1];
     node.roll(180);
 
-  }
+  };
 
   // update function called per frame with delta time
   self.update = function(timeStep) {
@@ -83,6 +84,6 @@ exports.component = function(self) {
 
     }
 
-  }
+  };
 
-}
+};

--- a/SpaceGame/Resources/Components/Enemy.js
+++ b/SpaceGame/Resources/Components/Enemy.js
@@ -1,3 +1,4 @@
+/* global SpaceGame */
 'atomic component';
 
 exports.component = function(self) {
@@ -22,7 +23,7 @@ exports.component = function(self) {
 
     SpaceGame.removeEnemy(self);
 
-  }
+  };
 
   self.start = function() {
 
@@ -45,7 +46,7 @@ exports.component = function(self) {
     self.dir = (Math.random() > .5);
 
 
-  }
+  };
 
   // update function called per frame with delta time
   self.update = function(timeStep) {
@@ -75,6 +76,6 @@ exports.component = function(self) {
     pos[1] += Math.sin(moveDelta) * .1;
     node.position2D = pos;
 
-  }
+  };
 
-}
+};

--- a/SpaceGame/Resources/Components/Explosion.js
+++ b/SpaceGame/Resources/Components/Explosion.js
@@ -25,7 +25,7 @@ exports.component = function(self) {
 
     // add a sprite component to our node
     var sprite2D = self.sprite2D = node.createComponent("StaticSprite2D");
-    sprite2D.blendMode = Atomic.BLEND_ADDALPHA
+    sprite2D.blendMode = Atomic.BLEND_ADDALPHA;
     sprite2D.sprite = sprites[0];
     node.position2D = self.spawnPosition;
     node.scale2D = [1.5, 1.5];
@@ -37,7 +37,7 @@ exports.component = function(self) {
 
     self.soundSource.play(boomSound);
 
-  }
+  };
 
   // update function called per frame with delta time
   self.update = function(timeStep) {
@@ -54,6 +54,6 @@ exports.component = function(self) {
       self.sprite2D.sprite = sprites[frame];
     }
 
-  }
+  };
 
-}
+};

--- a/SpaceGame/Resources/Components/HUD.js
+++ b/SpaceGame/Resources/Components/HUD.js
@@ -1,3 +1,4 @@
+/* global SpaceGame */
 'atomic component';
 
 exports.component = function(self) {
@@ -18,7 +19,7 @@ exports.component = function(self) {
 
   self.cleanup = function() {
     view.removeChild(layout);
-  }
+  };
 
   var scoretext = layout.getWidget("scoretext");
 
@@ -28,18 +29,18 @@ exports.component = function(self) {
 
     scoretext.text = "Score: " + value;
 
-  }
+  };
 
   self.updateHealth = function(value) {
 
     //healthText.text = "Health: " + value;
 
-  }
+  };
 
   self.updateGameText = function(text) {
 
     //gameText.text = text;
 
-  }
+  };
 
-}
+};

--- a/SpaceGame/Resources/Components/Player.js
+++ b/SpaceGame/Resources/Components/Player.js
@@ -1,3 +1,4 @@
+/* global SpaceGame */
 'atomic component';
 
 exports.component = function(self) {
@@ -30,7 +31,7 @@ exports.component = function(self) {
 
     }
 
-  }
+  };
 
   function doShooting(timeStep) {
     if (self.shootDelta > 0) {
@@ -90,7 +91,7 @@ exports.component = function(self) {
 
     node.position2D = [0, -SpaceGame.halfHeight + .65];
 
-  }
+  };
 
   self.update = function(timeStep) {
 
@@ -100,6 +101,6 @@ exports.component = function(self) {
     if (self.allowMove)
       moveShip(timeStep);
 
-  }
+  };
 
-}
+};

--- a/SpaceGame/Resources/Components/SpaceBackground.js
+++ b/SpaceGame/Resources/Components/SpaceBackground.js
@@ -19,7 +19,7 @@ exports.component = function(self) {
     sprite2D.blendMode = Atomic.BLEND_ADDALPHA;
     sprite2D.sprite = spaceSprite;
 
-  }
+  };
 
   self.update = function(timeStep) {
 
@@ -29,6 +29,6 @@ exports.component = function(self) {
     var speed = .75;
     node.translate([0, -timeStep * speed, 0]);
 
-  }
+  };
 
-}
+};

--- a/SpaceGame/Resources/Components/SpaceGame.js
+++ b/SpaceGame/Resources/Components/SpaceGame.js
@@ -1,7 +1,8 @@
+/* global SpaceGame */
 'atomic component';
 
 var UI = require("UI/ui");
-var options = require("UI/options")
+var options = require("UI/options");
 
 exports.component = function(self) {
 
@@ -27,14 +28,14 @@ exports.component = function(self) {
 
   self.random = function random(min, max) {
     return Math.random() * (max - min) + min;
-  }
+  };
 
   self.spawnBullet = function(pos, isPlayer) {
 
     var bulletNode = self.myscene.createChild("Bullet");
     var bullet = bulletNode.createJSComponent("Components/Bullet.js");
     bullet.init(isPlayer, pos);
-  }
+  };
 
   self.removeEnemy = function(enemy) {
 
@@ -43,7 +44,7 @@ exports.component = function(self) {
     self.enemies.splice(self.enemies.indexOf(enemy), 1);
 
     Atomic.destroy(enemy.node);
-  }
+  };
 
   self.capitalShipDestroyed = function() {
 
@@ -54,7 +55,7 @@ exports.component = function(self) {
     Atomic.destroy(self.capitalShipNode);
     self.capitalShipNode = self.capitalShip = null;
 
-  }
+  };
 
 
   function spawnEnemies() {
@@ -133,7 +134,7 @@ exports.component = function(self) {
     SpaceGame = null;
 
 
-  }
+  };
 
   self.win = function() {
 
@@ -142,7 +143,7 @@ exports.component = function(self) {
     UI.showGameOver();
     //self.cleanup();
 
-  }
+  };
 
   self.lose = function() {
 
@@ -151,7 +152,7 @@ exports.component = function(self) {
     UI.showGameOver();
     //self.cleanup();
 
-  }
+  };
 
   function spawnPlayer() {
 
@@ -249,12 +250,12 @@ exports.component = function(self) {
     spawnPlayer();
     spawnEnemies();
 
-  }
+  };
 
 
   self.update = function(timeStep) {
 
     updateEnemies(timeStep);
 
-  }
-}
+  };
+};

--- a/SpaceGame/Resources/Modules/DPad.js
+++ b/SpaceGame/Resources/Modules/DPad.js
@@ -51,7 +51,7 @@ function DPad() {
         //if we are using custom view, then just set dpad position
         this.dpad.setPosition(-width/3, height/4);
       }
-    }
+    };
     //adds horizontal and vertical buttons
     this.addAll = function() {
       //adds horizontal buttons
@@ -59,7 +59,7 @@ function DPad() {
       //adds vertical buttons
       this.addVertical();
 
-    }
+    };
     //adds horizontal buttons
     this.addHorizontal = function() {
       //if layout params doesn't exist create a new one
@@ -90,7 +90,7 @@ function DPad() {
       Atomic.input.bindButton(this.rightButton, Atomic.KEY_RIGHT);
       Atomic.input.bindButton(this.leftButton, Atomic.KEY_LEFT);
 
-    }
+    };
     //adds vertical buttons
     this.addVertical = function() {
       //if layout params doesn't exist create a new one
@@ -120,7 +120,7 @@ function DPad() {
       Atomic.input.bindButton(this.upButton, Atomic.KEY_UP);
       Atomic.input.bindButton(this.downButton, Atomic.KEY_DOWN);
 
-    }
+    };
 
     //inits layout prams for up/down buttons
     this.initUpDownLayoutParams = function() {
@@ -136,7 +136,7 @@ function DPad() {
       this.layoutParamsUpDown.maxWidth = verticButtonsSize[0]*6;
       this.layoutParamsUpDown.maxHeight = verticButtonsSize[1]*6;
 
-    }
+    };
 
     //inits layout params for left/right buttons
     this.initLeftRightLayoutParams = function() {
@@ -152,32 +152,32 @@ function DPad() {
       this.layoutParamsLeftRight.maxWidth = horizButtonsSize[0]*6;
       this.layoutParamsLeftRight.maxHeight = horizButtonsSize[1]*6;
 
-    }
+    };
 
     //set horizontal spacing
     this.setSpacingX = function(spacing) {
       dpadSpacingX = spacing;
       this.dpad.spacing = spacing;
-    }
+    };
 
     //set vertical spacing
     this.setSpacingY = function(spacing) {
       dpadSpacingY = spacing;
       this.upDownLayout.spacing = spacing;
-    }
+    };
 
     //set view position
     this.setPosition = function(x, y) {
       this.view.setPosition(x, y);
-    }
+    };
 
     this.updateViewSize = function() {
       this.view.setSize(horizButtonsSize[0]*4+verticButtonsSize[0]*2+dpadSpacingX, horizButtonsSize[1]*2+verticButtonsSize[1]*4+dpadSpacingY);
-    }
+    };
 
     this.remove = function() {
       this.view.removeChild(this.dpad);
-    }
+    };
 }
 
 module.exports = DPad;

--- a/SpaceGame/Resources/Modules/Game.js
+++ b/SpaceGame/Resources/Modules/Game.js
@@ -1,4 +1,4 @@
-
+/* global __js_atomicgame_update */
 Atomic.editor = null;
 
 function Game() {
@@ -31,13 +31,13 @@ Game.prototype.init = function(start, update) {
     if (typeof(start) === "function")
         start();
 
-}
+};
 
 Game.prototype.getSpriteSheet2D = function(xmlFile) {
 
 	return this.cache.getResource("SpriteSheet2D", xmlFile);
 
-}
+};
 
 Game.prototype.getSpriteSheet = Game.prototype.getSpriteSheet2D;
 
@@ -45,13 +45,13 @@ Game.prototype.getSound = function(soundFile) {
 
     return this.cache.getResource("Sound", soundFile);
 
-}
+};
 
 Game.prototype.getSprite2D = function(spriteFile) {
 
     return this.cache.getResource("Sprite2D", spriteFile);
 
-}
+};
 
 
 Game.prototype.showDebugHud = function() {
@@ -61,7 +61,7 @@ Game.prototype.showDebugHud = function() {
     debugHud.defaultStyle = uiStyle;
     debugHud.toggleAll();
 
-}
+};
 
 Game.prototype.createScene2D = function() {
 
@@ -91,7 +91,7 @@ Game.prototype.createScene2D = function() {
 
     return scene;
 
-}
+};
 
 Game.prototype.dumpMetrics = function() {
 
@@ -110,7 +110,7 @@ Game.prototype.dumpMetrics = function() {
   print("--------------");
   metrics.dumpJSComponents();
 
-}
+};
 
 Game.prototype.createScene3D = function(filename) {
 
@@ -127,7 +127,7 @@ Game.prototype.createScene3D = function(filename) {
     this.camera = camera;
 
     if (typeof(filename) == "string")
-        scene.loadXML(filename)
+        scene.loadXML(filename);
     else
         scene.createComponent("Octree");
 
@@ -146,7 +146,7 @@ Game.prototype.createScene3D = function(filename) {
 
     return scene;
 
-}
+};
 
 
 Atomic.game = exports.game = new Game();

--- a/SpaceGame/Resources/Scripts/precache.js
+++ b/SpaceGame/Resources/Scripts/precache.js
@@ -8,7 +8,7 @@ var resources =  {
   "Sounds/laser01.wav" : "Sound",
   "Sounds/laser02.wav" : "Sound",
   "Sprites/explosions_sheet.xml" : "SpriteSheet2D"
-}
+};
 
 // precache resources so they are ready to go
 exports.precache = function(verbose) {
@@ -21,4 +21,4 @@ exports.precache = function(verbose) {
       print("Precaching: ", resources[key], " ", key);
   });
 
-}
+};

--- a/SpaceGame/Resources/Scripts/utils.js
+++ b/SpaceGame/Resources/Scripts/utils.js
@@ -11,4 +11,4 @@ exports.playMusic = function(soundFile) {
 	musicSource.play(musicFile);
 
 
-}
+};

--- a/SpaceGame/Resources/UI/about.js
+++ b/SpaceGame/Resources/UI/about.js
@@ -41,12 +41,12 @@ exports.init = function(onClose) {
     closeWindow();
     onClose();
 
-  }
+  };
 
-}
+};
 
 exports.shutdown = function() {
 
   closeWindow();
 
-}
+};

--- a/SpaceGame/Resources/UI/gameOver.js
+++ b/SpaceGame/Resources/UI/gameOver.js
@@ -1,3 +1,4 @@
+/* global SpaceGame */
 'use strict';
 
 var game = Atomic.game;
@@ -33,13 +34,13 @@ exports.init = function() {
     closeWindow();
     var ui = require("./ui");
     ui.showMainMenu();
-  }
+  };
 
 
-}
+};
 
 exports.shutdown = function() {
 
   closeWindow();
 
-}
+};

--- a/SpaceGame/Resources/UI/mainMenu.js
+++ b/SpaceGame/Resources/UI/mainMenu.js
@@ -40,7 +40,7 @@ exports.init = function() {
   	var node = game.scene.createChild("SpaceGame");
   	node.createJSComponent("Components/SpaceGame.js");
 
-  }
+  };
 
   window.getWidget("about").onClick = function () {
 
@@ -50,7 +50,7 @@ exports.init = function() {
     var ui = require("./ui");
     ui.showAbout(function() {window.setState(UI.WIDGET_STATE_DISABLED, false);});
 
-  }
+  };
 
   window.getWidget("options").onClick = function () {
 
@@ -60,20 +60,20 @@ exports.init = function() {
     var ui = require("./ui");
     ui.showOptions(function() {window.setState(UI.WIDGET_STATE_DISABLED, false);});
 
-  }
+  };
 
 
   window.getWidget("quit").onClick = function () {
     
     game.engine.exit();
 
-  }
+  };
 
 
-}
+};
 
 exports.shutdown = function() {
 
   closeWindow();
 
-}
+};

--- a/SpaceGame/Resources/UI/options.js
+++ b/SpaceGame/Resources/UI/options.js
@@ -21,9 +21,9 @@ var blurSetting = false;
 exports.getOptions = function() {
   return {
     "blackAndWhite": blackAndWhiteSetting,
-    "blur": blurSetting,
-  }
-}
+    "blur": blurSetting
+  };
+};
 
 exports.init = function(onClose) {
 
@@ -47,27 +47,27 @@ exports.init = function(onClose) {
 
     blackAndWhiteSetting = blackAndWhite.value;
 
-  }
+  };
 
   blur.onChanged = function() {
 
     blurSetting = blur.value;
 
-  }
+  };
 
   window.getWidget("ok").onClick = function () {
 
     closeWindow();
     onClose();
 
-  }
+  };
 
 
 
-}
+};
 
 exports.shutdown = function() {
 
   closeWindow();
 
-}
+};

--- a/SpaceGame/Resources/UI/ui.js
+++ b/SpaceGame/Resources/UI/ui.js
@@ -8,25 +8,25 @@ var options = require("./options");
 exports.showMainMenu = function() {
 
     mainMenu.init();
-}
+};
 
 exports.showGameOver = function() {
 
     gameOver.init();
-}
+};
 
 exports.showAbout = function(onClose) {
 
     about.init(onClose);
-}
+};
 
 exports.showOptions = function(onClose) {
 
     options.init(onClose);
-}
+};
 
 
 exports.update = function(timeStep) {
 
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/Components/AI.js
+++ b/SpaceGameMultiplayer/Resources/Components/AI.js
@@ -1,3 +1,4 @@
+/* global SpaceGame */
 'atomic component';
 
 exports.component = function(self) {
@@ -12,7 +13,7 @@ exports.component = function(self) {
   self.start = function() {
 
 
-  }
+  };
 
   self.update = function(timeStep) {
 
@@ -56,6 +57,6 @@ exports.component = function(self) {
       SpaceGame.spawnBullet(pos, false);
     }
 
-  }
+  };
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/Components/Bullet.js
+++ b/SpaceGameMultiplayer/Resources/Components/Bullet.js
@@ -1,3 +1,4 @@
+/* global SpaceGame */
 'atomic component';
 
 exports.component = function(self) {
@@ -32,7 +33,7 @@ exports.component = function(self) {
       node.roll(180);
     }
 
-  }
+  };
 
   function updateEnemyBullet() {
 
@@ -120,6 +121,6 @@ exports.component = function(self) {
       }
     }
 
-  }
+  };
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/Components/CapitalShip.js
+++ b/SpaceGameMultiplayer/Resources/Components/CapitalShip.js
@@ -1,3 +1,4 @@
+/* global SpaceGame */
 'atomic component';
 
 exports.component = function(self) {
@@ -23,11 +24,11 @@ exports.component = function(self) {
     self.health--;
     if (!self.health) {
       die();
-      
+
       SpaceGame.respawnCapitalShip();
     }
 
-  }
+  };
 
   function die() {
 
@@ -67,7 +68,7 @@ exports.component = function(self) {
     node.position2D = [-4, SpaceGame.halfHeight - 1];
     node.roll(180);
 
-  }
+  };
 
   // update function called per frame with delta time
   self.update = function(timeStep) {
@@ -84,6 +85,6 @@ exports.component = function(self) {
 
     }
 
-  }
+  };
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/Components/Enemy.js
+++ b/SpaceGameMultiplayer/Resources/Components/Enemy.js
@@ -1,3 +1,4 @@
+/* global SpaceGame */
 'atomic component';
 
 exports.component = function(self) {
@@ -22,7 +23,7 @@ exports.component = function(self) {
 
     SpaceGame.removeEnemy(self);
 
-  }
+  };
 
   self.start = function() {
 
@@ -45,7 +46,7 @@ exports.component = function(self) {
     self.dir = (Math.random() > .5);
 
 
-  }
+  };
 
   // update function called per frame with delta time
   self.update = function(timeStep) {
@@ -75,6 +76,6 @@ exports.component = function(self) {
     pos[1] += Math.sin(moveDelta) * .1;
     node.position2D = pos;
 
-  }
+  };
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/Components/Explosion.js
+++ b/SpaceGameMultiplayer/Resources/Components/Explosion.js
@@ -25,7 +25,7 @@ exports.component = function(self) {
 
     // add a sprite component to our node
     var sprite2D = self.sprite2D = node.createComponent("StaticSprite2D");
-    sprite2D.blendMode = Atomic.BLEND_ADDALPHA
+    sprite2D.blendMode = Atomic.BLEND_ADDALPHA;
     sprite2D.sprite = sprites[0];
     node.position2D = self.spawnPosition;
     node.scale2D = [1.5, 1.5];
@@ -37,7 +37,7 @@ exports.component = function(self) {
 
     self.soundSource.play(boomSound);
 
-  }
+  };
 
   // update function called per frame with delta time
   self.update = function(timeStep) {
@@ -54,6 +54,6 @@ exports.component = function(self) {
       self.sprite2D.sprite = sprites[frame];
     }
 
-  }
+  };
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/Components/HUD.js
+++ b/SpaceGameMultiplayer/Resources/Components/HUD.js
@@ -13,10 +13,10 @@ exports.component = function(self) {
   layout.load("UI/Hud.ui.txt");
   layout.setSize(game.graphics.width, game.graphics.height);
   view.addChild(layout);
-  
+
   self.cleanup = function() {
     view.removeChild(layout);
-  }
+  };
 
   var scoretext = layout.getWidget("scoretext");
 
@@ -26,18 +26,18 @@ exports.component = function(self) {
 
     scoretext.text = "Score: " + value;
 
-  }
+  };
 
   self.updateHealth = function(value) {
 
     //healthText.text = "Health: " + value;
 
-  }
+  };
 
   self.updateGameText = function(text) {
 
     //gameText.text = text;
 
-  }
+  };
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/Components/Player.js
+++ b/SpaceGameMultiplayer/Resources/Components/Player.js
@@ -1,3 +1,4 @@
+/* global SpaceGame */
 'atomic component';
 
 exports.component = function(self) {
@@ -30,7 +31,7 @@ exports.component = function(self) {
     //
     //}
 
-  }
+  };
 
   function doShooting(timeStep) {
     if (self.shootDelta > 0) {
@@ -90,7 +91,7 @@ exports.component = function(self) {
 
     node.position2D = [0, -SpaceGame.halfHeight + .65];
 
-  }
+  };
 
   self.update = function(timeStep) {
 
@@ -100,6 +101,6 @@ exports.component = function(self) {
     if (self.allowMove)
       moveShip(timeStep);
 
-  }
+  };
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/Components/RemotePlayer.js
+++ b/SpaceGameMultiplayer/Resources/Components/RemotePlayer.js
@@ -1,3 +1,4 @@
+/* global SpaceGame */
 'atomic component';
 
 exports.component = function(self) {
@@ -25,7 +26,7 @@ exports.component = function(self) {
 
     print("Testing Port");
     print( self.serverToClientConnection.getPort());
-  }
+  };
 
   self.onHit = function() {
 
@@ -42,7 +43,7 @@ exports.component = function(self) {
       // SpaceGame.lose();
     }
 
-  }
+  };
 
   function isKeyDown(key) {
     if (!self.serverToClientConnection) {
@@ -106,7 +107,7 @@ exports.component = function(self) {
 
     node.position2D = [SpaceGame.halfWidth, -SpaceGame.halfHeight + .65];
 
-  }
+  };
 
   self.update = function(timeStep) {
 
@@ -120,6 +121,6 @@ exports.component = function(self) {
     if (self.allowMove)
       moveShip(timeStep);
 
-  }
+  };
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/Components/RemotePlayerClient.js
+++ b/SpaceGameMultiplayer/Resources/Components/RemotePlayerClient.js
@@ -16,7 +16,7 @@ exports.component = function(self) {
 
     var hudnode = game.scene.createChild();
     self.hud = hudnode.createJSComponent("Components/HUD.js");
-    
+
     Atomic.network.subscribeToEvent("NetworkStringMessage", function(msg) {
       var data = JSON.parse(msg['Data']);
 
@@ -24,22 +24,22 @@ exports.component = function(self) {
         self.updateScore(data.score);
       }
     });
-  }
+  };
 
   self.cleanup = function() {
     print("In cleanup for RemotePlayerClient");
     self.hud.cleanup();
-  }
-  
+  };
+
   self.updateScore = function(score) {
     self.hud.updateScore(score);
-  }
-  
+  };
+
   self.update = function(timeStep) {
     if (!self.clientToServerConnection) {
       return;
     }
-    
+
     var leftKeyDown = false;
     var rightKeyDown = false;
     var shootKeyDown = false;
@@ -57,6 +57,6 @@ exports.component = function(self) {
     self.clientToServerConnection.setControlButtons(KEY_LEFT,leftKeyDown);
     self.clientToServerConnection.setControlButtons(KEY_RIGHT,rightKeyDown);
     self.clientToServerConnection.setControlButtons(KEY_SHOOT,shootKeyDown);
-  }
+  };
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/Components/SpaceBackground.js
+++ b/SpaceGameMultiplayer/Resources/Components/SpaceBackground.js
@@ -19,7 +19,7 @@ exports.component = function(self) {
     sprite2D.blendMode = Atomic.BLEND_ADDALPHA;
     sprite2D.sprite = spaceSprite;
 
-  }
+  };
 
   self.update = function(timeStep) {
 
@@ -29,6 +29,6 @@ exports.component = function(self) {
     var speed = .75;
     node.translate([0, -timeStep * speed, 0]);
 
-  }
+  };
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/Components/SpaceGame.js
+++ b/SpaceGameMultiplayer/Resources/Components/SpaceGame.js
@@ -1,7 +1,8 @@
+/* global SpaceGame */
 'atomic component';
 
 var UI = require("UI/ui");
-var options = require("UI/options")
+var options = require("UI/options");
 
 exports.component = function(self) {
 
@@ -38,18 +39,18 @@ exports.component = function(self) {
 
       connection.sendStringMessage(msg);
     }
-  }
+  };
 
   self.random = function random(min, max) {
     return Math.random() * (max - min) + min;
-  }
+  };
 
   self.spawnBullet = function(pos, isPlayer) {
 
     var bulletNode = self.myscene.createChild("Bullet");
     var bullet = bulletNode.createJSComponent("Components/Bullet.js");
     bullet.init(isPlayer, pos);
-  }
+  };
 
   self.removeEnemy = function(enemy) {
 
@@ -62,7 +63,7 @@ exports.component = function(self) {
     if (self.enemies.length === 0) {
       self.respawnEnemies();
     }
-  }
+  };
 
   self.capitalShipDestroyed = function() {
 
@@ -72,12 +73,12 @@ exports.component = function(self) {
     Atomic.destroy(self.capitalShipNode);
     self.capitalShipNode = self.capitalShip = null;
 
-  }
+  };
 
   self.respawnCapitalShip = function() {
     self.capitalShipNode = self.myscene.createChild("CapitalShip");
     self.capitalShip = self.capitalShipNode.createJSComponent("Components/CapitalShip.js");
-  }
+  };
 
   self.respawnEnemies = function() {
     var pos = [0, 0];
@@ -106,7 +107,7 @@ exports.component = function(self) {
       pos[1] -= 0.75;
 
     }
-  }
+  };
 
   function spawnEnemies() {
 
@@ -156,7 +157,7 @@ exports.component = function(self) {
     SpaceGame = null;
 
 
-  }
+  };
 
   self.win = function() {
 
@@ -165,7 +166,7 @@ exports.component = function(self) {
     UI.showGameOver();
     //self.cleanup();
 
-  }
+  };
 
   self.lose = function() {
 
@@ -174,7 +175,7 @@ exports.component = function(self) {
     UI.showGameOver();
     //self.cleanup();
 
-  }
+  };
 
   function spawnPlayer() {
     self.playerNode = self.myscene.createChild("Player");
@@ -190,7 +191,7 @@ exports.component = function(self) {
 
     clientConnectionToNodeMap[connection] = remotePlayerNode;
     clientConnectionKeyToConnectionMap[connection] = connection;
-  }
+  };
 
 
   function createScene() {
@@ -320,12 +321,12 @@ exports.component = function(self) {
         self.updateScore();
       }
     });
-  }
+  };
 
 
   self.update = function(timeStep) {
 
     updateEnemies(timeStep);
 
-  }
-}
+  };
+};

--- a/SpaceGameMultiplayer/Resources/Modules/DPad.js
+++ b/SpaceGameMultiplayer/Resources/Modules/DPad.js
@@ -51,7 +51,7 @@ function DPad() {
         //if we are using custom view, then just set dpad position
         this.dpad.setPosition(-width/3, height/4);
       }
-    }
+    };
     //adds horizontal and vertical buttons
     this.addAll = function() {
       //adds horizontal buttons
@@ -59,7 +59,7 @@ function DPad() {
       //adds vertical buttons
       this.addVertical();
 
-    }
+    };
     //adds horizontal buttons
     this.addHorizontal = function() {
       //if layout params doesn't exist create a new one
@@ -90,7 +90,7 @@ function DPad() {
       Atomic.input.bindButton(this.rightButton, Atomic.KEY_RIGHT);
       Atomic.input.bindButton(this.leftButton, Atomic.KEY_LEFT);
 
-    }
+    };
     //adds vertical buttons
     this.addVertical = function() {
       //if layout params doesn't exist create a new one
@@ -120,7 +120,7 @@ function DPad() {
       Atomic.input.bindButton(this.upButton, Atomic.KEY_UP);
       Atomic.input.bindButton(this.downButton, Atomic.KEY_DOWN);
 
-    }
+    };
 
     //inits layout prams for up/down buttons
     this.initUpDownLayoutParams = function() {
@@ -136,7 +136,7 @@ function DPad() {
       this.layoutParamsUpDown.maxWidth = verticButtonsSize[0]*6;
       this.layoutParamsUpDown.maxHeight = verticButtonsSize[1]*6;
 
-    }
+    };
 
     //inits layout params for left/right buttons
     this.initLeftRightLayoutParams = function() {
@@ -152,32 +152,32 @@ function DPad() {
       this.layoutParamsLeftRight.maxWidth = horizButtonsSize[0]*6;
       this.layoutParamsLeftRight.maxHeight = horizButtonsSize[1]*6;
 
-    }
+    };
 
     //set horizontal spacing
     this.setSpacingX = function(spacing) {
       dpadSpacingX = spacing;
       this.dpad.spacing = spacing;
-    }
+    };
 
     //set vertical spacing
     this.setSpacingY = function(spacing) {
       dpadSpacingY = spacing;
       this.upDownLayout.spacing = spacing;
-    }
+    };
 
     //set view position
     this.setPosition = function(x, y) {
       this.view.setPosition(x, y);
-    }
+    };
 
     this.updateViewSize = function() {
       this.view.setSize(horizButtonsSize[0]*4+verticButtonsSize[0]*2+dpadSpacingX, horizButtonsSize[1]*2+verticButtonsSize[1]*4+dpadSpacingY);
-    }
+    };
 
     this.remove = function() {
       this.view.removeChild(this.dpad);
-    }
+    };
 }
 
 module.exports = DPad;

--- a/SpaceGameMultiplayer/Resources/Modules/Game.js
+++ b/SpaceGameMultiplayer/Resources/Modules/Game.js
@@ -1,4 +1,4 @@
-
+/* global __js_atomicgame_update */
 Atomic.editor = null;
 
 function Game() {
@@ -31,13 +31,13 @@ Game.prototype.init = function(start, update) {
     if (typeof(start) === "function")
         start();
 
-}
+};
 
 Game.prototype.getSpriteSheet2D = function(xmlFile) {
 
 	return this.cache.getResource("SpriteSheet2D", xmlFile);
 
-}
+};
 
 Game.prototype.getSpriteSheet = Game.prototype.getSpriteSheet2D;
 
@@ -45,13 +45,13 @@ Game.prototype.getSound = function(soundFile) {
 
     return this.cache.getResource("Sound", soundFile);
 
-}
+};
 
 Game.prototype.getSprite2D = function(spriteFile) {
 
     return this.cache.getResource("Sprite2D", spriteFile);
 
-}
+};
 
 
 Game.prototype.showDebugHud = function() {
@@ -61,7 +61,7 @@ Game.prototype.showDebugHud = function() {
     debugHud.defaultStyle = uiStyle;
     debugHud.toggleAll();
 
-}
+};
 
 Game.prototype.createScene2D = function() {
 
@@ -91,7 +91,7 @@ Game.prototype.createScene2D = function() {
 
     return scene;
 
-}
+};
 
 Game.prototype.dumpMetrics = function() {
 
@@ -110,7 +110,7 @@ Game.prototype.dumpMetrics = function() {
   print("--------------");
   metrics.dumpJSComponents();
 
-}
+};
 
 Game.prototype.createScene3D = function(filename) {
 
@@ -127,7 +127,7 @@ Game.prototype.createScene3D = function(filename) {
     this.camera = camera;
 
     if (typeof(filename) == "string")
-        scene.loadXML(filename)
+        scene.loadXML(filename);
     else
         scene.createComponent("Octree");
 
@@ -146,7 +146,7 @@ Game.prototype.createScene3D = function(filename) {
 
     return scene;
 
-}
+};
 
 
 Atomic.game = exports.game = new Game();

--- a/SpaceGameMultiplayer/Resources/Modules/LocalStorage.js
+++ b/SpaceGameMultiplayer/Resources/Modules/LocalStorage.js
@@ -14,7 +14,7 @@ var prefFilePath = documentsDir + PREFS_FILE;
 
 
 function LocalStorage() {
-    
+
 }
 
 function getJSONPrefData() {
@@ -45,7 +45,7 @@ LocalStorage.prototype.setServerName = function(serverName) {
 
     // close the file
     file.close();
-}
+};
 
 LocalStorage.prototype.getServerName = function() {
     var json = getJSONPrefData();
@@ -55,7 +55,7 @@ LocalStorage.prototype.getServerName = function() {
     }
 
     return "Server";
-}
+};
 
 LocalStorage.prototype.getServerPort = function() {
     var json = getJSONPrefData();
@@ -65,7 +65,7 @@ LocalStorage.prototype.getServerPort = function() {
     }
 
     return SERVER_PORT;
-}
+};
 
 LocalStorage.prototype.getMasterServerIP = function() {
     var json = getJSONPrefData();
@@ -75,7 +75,7 @@ LocalStorage.prototype.getMasterServerIP = function() {
     }
 
     return MASTER_SERVER_IP;
-}
+};
 
 LocalStorage.prototype.getMasterServerPort = function() {
     var json = getJSONPrefData();
@@ -85,7 +85,7 @@ LocalStorage.prototype.getMasterServerPort = function() {
     }
 
     return MASTER_SERVER_PORT;
-}
+};
 
 LocalStorage.prototype.setPlayerName = function(playerName) {
     var mydata = getJSONPrefData();
@@ -99,7 +99,7 @@ LocalStorage.prototype.setPlayerName = function(playerName) {
 
     // close the file
     file.close();
-}
+};
 
 LocalStorage.prototype.getPlayerName = function() {
     var json = getJSONPrefData();
@@ -109,7 +109,7 @@ LocalStorage.prototype.getPlayerName = function() {
     }
 
     return "Player";
-}
+};
 
 
 Atomic.localStorage = exports.localStorage = new LocalStorage();

--- a/SpaceGameMultiplayer/Resources/Scripts/precache.js
+++ b/SpaceGameMultiplayer/Resources/Scripts/precache.js
@@ -8,7 +8,7 @@ var resources =  {
   "Sounds/laser01.wav" : "Sound",
   "Sounds/laser02.wav" : "Sound",
   "Sprites/explosions_sheet.xml" : "SpriteSheet2D"
-}
+};
 
 // precache resources so they are ready to go
 exports.precache = function(verbose) {
@@ -21,4 +21,4 @@ exports.precache = function(verbose) {
       print("Precaching: ", resources[key], " ", key);
   });
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/Scripts/utils.js
+++ b/SpaceGameMultiplayer/Resources/Scripts/utils.js
@@ -10,4 +10,4 @@ exports.playMusic = function(soundFile) {
 	musicSource.play(musicFile);
 
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/UI/about.js
+++ b/SpaceGameMultiplayer/Resources/UI/about.js
@@ -41,12 +41,12 @@ exports.init = function(onClose) {
     closeWindow();
     onClose();
 
-  }
+  };
 
-}
+};
 
 exports.shutdown = function() {
 
   closeWindow();
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/UI/gameOver.js
+++ b/SpaceGameMultiplayer/Resources/UI/gameOver.js
@@ -1,3 +1,4 @@
+/*global SpaceGame */
 'use strict';
 
 var game = Atomic.game;
@@ -33,13 +34,13 @@ exports.init = function() {
     closeWindow();
     var ui = require("./ui");
     ui.showMainMenu();
-  }
+  };
 
 
-}
+};
 
 exports.shutdown = function() {
 
   closeWindow();
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/UI/joinServer.js
+++ b/SpaceGameMultiplayer/Resources/UI/joinServer.js
@@ -111,7 +111,7 @@ exports.init = function(onClose) {
     window.getWidget("cancel").onClick = function () {
         closeWindow();
         onClose();
-    }
+    };
 
     window.getWidget("ok").onClick = function () {
         var selectedItemId = serverSelect.getSelectedItemID();
@@ -124,12 +124,12 @@ exports.init = function(onClose) {
         ui.closeMainMenu();
 
         connectToServer(server);
-    }
+    };
 
-}
+};
 
 exports.shutdown = function() {
 
     closeWindow();
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/UI/mainMenu.js
+++ b/SpaceGameMultiplayer/Resources/UI/mainMenu.js
@@ -29,7 +29,7 @@ exports.init = function() {
 
   var spaceNode = game.scene.createChild("SpaceBackground");
   spaceNode.createJSComponent("Components/SpaceBackground.js");
-  
+
   window.load("UI/mainMenu.ui.txt");
   window.resizeToFitContent();
   view.addChild(window);
@@ -39,7 +39,7 @@ exports.init = function() {
   if(Atomic.platform == "iOS") {
    window.getWidget("quit").visibility = Atomic.UI_WIDGET_VISIBILITY_GONE;
   }
-    
+
 
   window.getWidget("new_game").onClick = function () {
 
@@ -49,16 +49,16 @@ exports.init = function() {
 
     var node = game.scene.createChild("SpaceGame");
     node.createJSComponent("Components/SpaceGame.js");
-  }
+  };
 
   window.getWidget("about").onClick = function () {
-    
+
     // disable ourselves until ok is clicked on about
     window.setState(UI.WIDGET_STATE_DISABLED, true);
 
     var ui = require("./ui");
     ui.showAbout(function() {window.setState(UI.WIDGET_STATE_DISABLED, false);});
-  }
+  };
 
   window.getWidget("join_server").onClick = function() {
     // disable ourselves until ok is clicked on about
@@ -66,8 +66,8 @@ exports.init = function() {
 
     var ui = require("./ui");
     ui.showJoinServer(function() {window.setState(UI.WIDGET_STATE_DISABLED, false);});
-  }
-  
+  };
+
   window.getWidget("options").onClick = function () {
 
     // disable ourselves until ok is clicked on about
@@ -76,14 +76,14 @@ exports.init = function() {
     var ui = require("./ui");
     ui.showOptions(function() {window.setState(UI.WIDGET_STATE_DISABLED, false);});
 
-  }
+  };
 
 
   window.getWidget("quit").onClick = function () {
-    
+
     game.engine.exit();
 
-  }
+  };
 
   window.getWidget("join_server").onClick = function () {
     // disable ourselves until ok is clicked on about
@@ -91,16 +91,16 @@ exports.init = function() {
 
     var ui = require("./ui");
     ui.showJoinServer(function() {window.setState(UI.WIDGET_STATE_DISABLED, false);});
-  }
+  };
 
-}
+};
 
 exports.shutdown = function() {
 
   closeWindow();
 
-}
+};
 
 exports.closeMainMenu = function() {
   closeWindow();
-}
+};

--- a/SpaceGameMultiplayer/Resources/UI/options.js
+++ b/SpaceGameMultiplayer/Resources/UI/options.js
@@ -22,9 +22,9 @@ var blurSetting = false;
 exports.getOptions = function() {
   return {
     "blackAndWhite": blackAndWhiteSetting,
-    "blur": blurSetting,
-  }
-}
+    "blur": blurSetting
+  };
+};
 
 exports.init = function(onClose) {
 
@@ -48,9 +48,9 @@ exports.init = function(onClose) {
 
     blackAndWhiteSetting = blackAndWhite.value;
 
-  }
+  };
 
-  
+
   window.getWidget("server_name").setText(localStorage.getServerName());
   window.getWidget("player_name").setText(localStorage.getPlayerName());
 
@@ -59,27 +59,27 @@ exports.init = function(onClose) {
 
     blurSetting = blur.value;
 
-  }
+  };
 
   window.getWidget("ok").onClick = function () {
-    
+
     var serverName = window.getWidget("server_name").getText();
     var playerName = window.getWidget("player_name").getText();
-    
+
     localStorage.setServerName(serverName);
     localStorage.setPlayerName(playerName);
-    
+
     closeWindow();
     onClose();
 
-  }
+  };
 
 
 
-}
+};
 
 exports.shutdown = function() {
 
   closeWindow();
 
-}
+};

--- a/SpaceGameMultiplayer/Resources/UI/ui.js
+++ b/SpaceGameMultiplayer/Resources/UI/ui.js
@@ -9,33 +9,33 @@ var joinServer = require("./joinServer");
 exports.showMainMenu = function() {
 
     mainMenu.init();
-}
+};
 
 exports.showGameOver = function() {
 
     gameOver.init();
-}
+};
 
 exports.showAbout = function(onClose) {
 
     about.init(onClose);
-}
+};
 
 exports.showOptions = function(onClose) {
 
     options.init(onClose);
-}
+};
 
 exports.showJoinServer = function(onClose) {
 
     joinServer.init(onClose);
-}
+};
 
 exports.update = function(timeStep) {
 
 
-}
+};
 
 exports.closeMainMenu = function() {
     mainMenu.closeMainMenu();
-}
+};

--- a/TestInspectorFields/Resources/Components/Star.js
+++ b/TestInspectorFields/Resources/Components/Star.js
@@ -12,7 +12,7 @@ var inspectorFields = {
   colorField: [Atomic.VAR_COLOR, [1, 2, 3, 4]],
   texture2DNoDefault: ["Texture2D"],
   sprite2D: ["Sprite2D", "Sprites/star.png"]
-}
+};
 
 exports.component = function(self) {
 
@@ -20,6 +20,6 @@ exports.component = function(self) {
 
     self.node.rotate2D(timeStep * 75 * self.numberField);
 
-  }
+  };
 
-}
+};

--- a/ToonTown/Resources/Components/AvatarController.js
+++ b/ToonTown/Resources/Components/AvatarController.js
@@ -10,7 +10,7 @@ var vec3 = glmatrix.vec3;
 var inspectorFields = {
   //needs default value to make editor understand type of that value
   speed: 1.0
-}
+};
 //define a component AvatarController
 exports.component = function(self) {
   //link to the current node
@@ -69,16 +69,17 @@ exports.component = function(self) {
     var shape = node.createComponent("CollisionShape");
     shape.setCapsule(2, 4, [0, 2, 0]);
 
-  }
+  };
 
   self.fixedUpdate = function(timestep) {
 
     //get a RigidBody component from the current node
     var body = node.getComponent("RigidBody");
+    var inAirTimer = 0.0;
 
     // Update the in air timer. Reset if grounded
     if (!onGround)
-    inAirTimer += timeStep;
+    inAirTimer += timestep;
     else
     inAirTimer = 0.0;
 
@@ -98,16 +99,16 @@ exports.component = function(self) {
 
     if (cameraMode != 2) {
       if (moveForward) {
-        vec3.add(moveDir, moveDir, [0, 0, 1])
+        vec3.add(moveDir, moveDir, [0, 0, 1]);
       }
       if (moveBackwards) {
-        vec3.add(moveDir, moveDir, [0, 0, -1])
+        vec3.add(moveDir, moveDir, [0, 0, -1]);
       }
       if (moveLeft) {
-        vec3.add(moveDir, moveDir, [-1, 0, 0])
+        vec3.add(moveDir, moveDir, [-1, 0, 0]);
       }
       if (moveRight) {
-        vec3.add(moveDir, moveDir, [1, 0, 0])
+        vec3.add(moveDir, moveDir, [1, 0, 0]);
       }
     }
 
@@ -153,7 +154,7 @@ exports.component = function(self) {
     // Reset grounded flag for next frame
     onGround = true;
 
-  }
+  };
 
   function MoveCamera(timeStep) {
 
@@ -178,13 +179,13 @@ exports.component = function(self) {
 
     //translate camera on the amount of speed value
     if (moveForward)
-      cameraNode.translate([0.0, 0.0, speed])
+      cameraNode.translate([0.0, 0.0, speed]);
     if (moveBackwards)
-      cameraNode.translate([0.0, 0.0, -speed])
+      cameraNode.translate([0.0, 0.0, -speed]);
     if (moveLeft)
-      cameraNode.translate([-speed, 0.0, 0.0])
+      cameraNode.translate([-speed, 0.0, 0.0]);
     if (moveRight)
-      cameraNode.translate([speed, 0.0, 0.0])
+      cameraNode.translate([speed, 0.0, 0.0]);
 
   }
 
@@ -262,7 +263,7 @@ exports.component = function(self) {
         cameraMode = 0;
     }
 
-  }
+  };
 
   //that function called right after update function
   self.postUpdate = function(timestep) {
@@ -271,7 +272,7 @@ exports.component = function(self) {
     var rot = node.getRotation();
 
     //create quaternion
-    dir = quat.create();
+    var dir = quat.create();
     //set X value
     quat.setAxisAngle(dir, [1, 0, 0], (pitch * Math.PI / 180.0));
 
@@ -314,8 +315,8 @@ exports.component = function(self) {
     else{
       MoveCamera(timestep);
     }
-  }
-}
+  };
+};
 
 function QuatFromEuler(x, y, z) {
     var M_PI = 3.14159265358979323846264338327950288;

--- a/ToonTown/Resources/Components/LightFlicker.js
+++ b/ToonTown/Resources/Components/LightFlicker.js
@@ -1,4 +1,4 @@
-"atomic component"
+"atomic component";
 
 // a flickering light component
 exports.component = function(self){
@@ -34,5 +34,5 @@ exports.component = function(self){
     if (self.light.range > targetValue)
       self.light.range -= timestep * 10;
 
-  }
-}
+  };
+};

--- a/ToonTown/Resources/Components/RoboMan.js
+++ b/ToonTown/Resources/Components/RoboMan.js
@@ -27,10 +27,10 @@ exports.component = function(self) {
     //rotate current node around Y axis
     node.yaw(180);
 
-  }
+  };
 
   self.update = function(timeStep) {
-    
+
     //rotate current node around Y axis
     node.yaw(180);
 
@@ -46,6 +46,6 @@ exports.component = function(self) {
 
     }
 
-  }
+  };
 
-}
+};

--- a/ToonTown/Resources/Components/Scene.js
+++ b/ToonTown/Resources/Components/Scene.js
@@ -1,4 +1,4 @@
-"atomic component"
+"atomic component";
 
 //Define a Scene component
 exports.component = function(self) {
@@ -66,11 +66,11 @@ exports.component = function(self) {
         //binds jumpButton to KEY_SPACE
         Atomic.input.bindButton(jumpButton, Atomic.KEY_SPACE);
       }
-  }
+  };
 
   self.update = function(timeStep) {
 
       time += timeStep * .04;
       self.procSky.setDayTime(time);
-  }
-}
+  };
+};

--- a/ToonTown/Resources/Modules/DPad.js
+++ b/ToonTown/Resources/Modules/DPad.js
@@ -51,7 +51,7 @@ function DPad() {
         //if we are using custom view, then just set dpad position
         this.dpad.setPosition(-width/3, height/4);
       }
-    }
+    };
     //adds horizontal and vertical buttons
     this.addAll = function() {
       //adds horizontal buttons
@@ -59,7 +59,7 @@ function DPad() {
       //adds vertical buttons
       this.addVertical();
 
-    }
+    };
     //adds horizontal buttons
     this.addHorizontal = function() {
       //if layout params doesn't exist create a new one
@@ -90,7 +90,7 @@ function DPad() {
       Atomic.input.bindButton(this.rightButton, Atomic.KEY_RIGHT);
       Atomic.input.bindButton(this.leftButton, Atomic.KEY_LEFT);
 
-    }
+    };
     //adds vertical buttons
     this.addVertical = function() {
       //if layout params doesn't exist create a new one
@@ -120,7 +120,7 @@ function DPad() {
       Atomic.input.bindButton(this.upButton, Atomic.KEY_UP);
       Atomic.input.bindButton(this.downButton, Atomic.KEY_DOWN);
 
-    }
+    };
 
     //inits layout prams for up/down buttons
     this.initUpDownLayoutParams = function() {
@@ -136,7 +136,7 @@ function DPad() {
       this.layoutParamsUpDown.maxWidth = verticButtonsSize[0]*6;
       this.layoutParamsUpDown.maxHeight = verticButtonsSize[1]*6;
 
-    }
+    };
 
     //inits layout params for left/right buttons
     this.initLeftRightLayoutParams = function() {
@@ -152,32 +152,32 @@ function DPad() {
       this.layoutParamsLeftRight.maxWidth = horizButtonsSize[0]*6;
       this.layoutParamsLeftRight.maxHeight = horizButtonsSize[1]*6;
 
-    }
+    };
 
     //set horizontal spacing
     this.setSpacingX = function(spacing) {
       dpadSpacingX = spacing;
       this.dpad.spacing = spacing;
-    }
+    };
 
     //set vertical spacing
     this.setSpacingY = function(spacing) {
       dpadSpacingY = spacing;
       this.upDownLayout.spacing = spacing;
-    }
+    };
 
     //set view position
     this.setPosition = function(x, y) {
       this.view.setPosition(x, y);
-    }
+    };
 
     this.updateViewSize = function() {
       this.view.setSize(horizButtonsSize[0]*4+verticButtonsSize[0]*2+dpadSpacingX, horizButtonsSize[1]*2+verticButtonsSize[1]*4+dpadSpacingY);
-    }
+    };
 
     this.remove = function() {
       this.view.removeChild(this.dpad);
-    }
+    };
 }
 
 module.exports = DPad;

--- a/UISceneView2D/Resources/Components/UI.js
+++ b/UISceneView2D/Resources/Components/UI.js
@@ -28,4 +28,4 @@ exports.component = function(self) {
     view.addChild(window);
     window.center();
 
-}
+};

--- a/WaterShip/Resources/Components/ProcSky.js
+++ b/WaterShip/Resources/Components/ProcSky.js
@@ -2,27 +2,27 @@
 "atomic component";
 
 var component = function (self) {
-    
+
   var scene = self.node;
   var time = 12;
-  
+
   // create the procedural sky
   var pnode = scene.createChild();
   self.procSky = pnode.createComponent("ProcSky");
   self.procSky.setDayTime(time);
-  
+
 
   self.start = function() {
 
-  }
+  };
 
   self.update = function(timeStep) {
-      
+
       time += timeStep * .5;
       self.procSky.setDayTime(time);
 
-  }
+  };
 
-}
+};
 
 exports.component = component;

--- a/WaterShip/Resources/Components/Spinner.js
+++ b/WaterShip/Resources/Components/Spinner.js
@@ -3,7 +3,7 @@
 
 var inspectorFields = {
   speed: 1.0
-}
+};
 
 exports.component = function(self) {
 
@@ -11,6 +11,6 @@ exports.component = function(self) {
 
     self.node.yaw(timeStep * 75 * self.speed);
 
-  }
+  };
 
-}
+};

--- a/WebTexture/Resources/Components/Spinner.js
+++ b/WebTexture/Resources/Components/Spinner.js
@@ -3,7 +3,7 @@
 
 var inspectorFields = {
   speed: 1.0
-}
+};
 
 exports.component = function(self) {
 
@@ -12,6 +12,6 @@ exports.component = function(self) {
     self.node.yaw(timeStep * 15 * self.speed);
     //self.node.roll(timeStep * 5 * self.speed);
 
-  }
+  };
 
-}
+};

--- a/WebTexture/Resources/Components/WebTexture.js
+++ b/WebTexture/Resources/Components/WebTexture.js
@@ -64,5 +64,5 @@ exports.component = function(self) {
       webClient.sendMouseWheelEvent(0, 0, 0, 0, -Atomic.input.mouseMoveWheel);
 
     }
-  }
-}
+  };
+};

--- a/WebView3D/Resources/Components/AvatarController.js
+++ b/WebView3D/Resources/Components/AvatarController.js
@@ -10,7 +10,7 @@ var vec3 = glmatrix.vec3;
 var inspectorFields = {
   //needs default value to make editor understand type of that value
   speed: 1.0
-}
+};
 //define a component AvatarController
 exports.component = function(self) {
   //link to the current node
@@ -69,16 +69,17 @@ exports.component = function(self) {
     var shape = node.createComponent("CollisionShape");
     shape.setCapsule(2, 4, [0, 2, 0]);
 
-  }
+  };
 
   self.fixedUpdate = function(timestep) {
 
     //get a RigidBody component from the current node
     var body = node.getComponent("RigidBody");
+    var inAirTimer = 0;
 
     // Update the in air timer. Reset if grounded
     if (!onGround)
-    inAirTimer += timeStep;
+    inAirTimer += timestep;
     else
     inAirTimer = 0.0;
 
@@ -98,16 +99,16 @@ exports.component = function(self) {
 
     if (cameraMode != 2) {
       if (moveForward) {
-        vec3.add(moveDir, moveDir, [0, 0, 1])
+        vec3.add(moveDir, moveDir, [0, 0, 1]);
       }
       if (moveBackwards) {
-        vec3.add(moveDir, moveDir, [0, 0, -1])
+        vec3.add(moveDir, moveDir, [0, 0, -1]);
       }
       if (moveLeft) {
-        vec3.add(moveDir, moveDir, [-1, 0, 0])
+        vec3.add(moveDir, moveDir, [-1, 0, 0]);
       }
       if (moveRight) {
-        vec3.add(moveDir, moveDir, [1, 0, 0])
+        vec3.add(moveDir, moveDir, [1, 0, 0]);
       }
     }
 
@@ -153,7 +154,7 @@ exports.component = function(self) {
     // Reset grounded flag for next frame
     onGround = true;
 
-  }
+  };
 
   function MoveCamera(timeStep) {
 
@@ -178,13 +179,13 @@ exports.component = function(self) {
 
     //translate camera on the amount of speed value
     if (moveForward)
-      cameraNode.translate([0.0, 0.0, speed])
+      cameraNode.translate([0.0, 0.0, speed]);
     if (moveBackwards)
-      cameraNode.translate([0.0, 0.0, -speed])
+      cameraNode.translate([0.0, 0.0, -speed]);
     if (moveLeft)
-      cameraNode.translate([-speed, 0.0, 0.0])
+      cameraNode.translate([-speed, 0.0, 0.0]);
     if (moveRight)
-      cameraNode.translate([speed, 0.0, 0.0])
+      cameraNode.translate([speed, 0.0, 0.0]);
 
   }
 
@@ -262,7 +263,7 @@ exports.component = function(self) {
         cameraMode = 0;
     }
 
-  }
+  };
 
   //that function called right after update function
   self.postUpdate = function(timestep) {
@@ -271,7 +272,7 @@ exports.component = function(self) {
     var rot = node.getRotation();
 
     //create quaternion
-    dir = quat.create();
+    var dir = quat.create();
     //set X value
     quat.setAxisAngle(dir, [1, 0, 0], (pitch * Math.PI / 180.0));
 
@@ -314,8 +315,8 @@ exports.component = function(self) {
     else{
       MoveCamera(timestep);
     }
-  }
-}
+  };
+};
 
 function QuatFromEuler(x, y, z) {
     var M_PI = 3.14159265358979323846264338327950288;

--- a/WebView3D/Resources/Components/LightFlicker.js
+++ b/WebView3D/Resources/Components/LightFlicker.js
@@ -1,4 +1,4 @@
-"atomic component"
+"atomic component";
 
 // a flickering light component
 exports.component = function(self){
@@ -34,5 +34,5 @@ exports.component = function(self){
     if (self.light.range > targetValue)
       self.light.range -= timestep * 10;
 
-  }
-}
+  };
+};

--- a/WebView3D/Resources/Components/RoboMan.js
+++ b/WebView3D/Resources/Components/RoboMan.js
@@ -27,10 +27,10 @@ exports.component = function(self) {
     //rotate current node around Y axis
     node.yaw(180);
 
-  }
+  };
 
   self.update = function(timeStep) {
-    
+
     //rotate current node around Y axis
     node.yaw(180);
 
@@ -46,6 +46,6 @@ exports.component = function(self) {
 
     }
 
-  }
+  };
 
-}
+};

--- a/WebView3D/Resources/Components/Scene.js
+++ b/WebView3D/Resources/Components/Scene.js
@@ -1,4 +1,4 @@
-"atomic component"
+"atomic component";
 
 //Define a Scene component
 exports.component = function(self) {
@@ -12,11 +12,11 @@ exports.component = function(self) {
       var pnode = scene.createChild();
       self.procSky = pnode.createComponent("ProcSky");
       self.procSky.setDayTime(time);
-  }
+  };
 
   self.update = function(timeStep) {
 
       time += timeStep * .08;
       self.procSky.setDayTime(time);
-  }
-}
+  };
+};

--- a/WebView3D/Resources/Components/WebTexture.js
+++ b/WebView3D/Resources/Components/WebTexture.js
@@ -76,5 +76,5 @@ exports.component = function(self) {
       webClient.sendMouseWheelEvent(0, 0, 0, 0, -Atomic.input.mouseMoveWheel);
 
     }
-  }
-}
+  };
+};

--- a/WebViewProperties/Resources/Components/WebView.js
+++ b/WebViewProperties/Resources/Components/WebView.js
@@ -31,7 +31,7 @@ exports.component = function(self) {
   view.addChild(window);
   window.center();
 
-}
+};
 
 // Simple example of access global properties
 function getHTML() {
@@ -53,6 +53,6 @@ function getHTML() {
   </script>\
   \
   </body>\
-  </html>"
+  </html>";
 
 }


### PR DESCRIPTION
ESLint now runs clean with all of the examples.  Most of the changes were adding semicolons or removing stray commas from object literals, but there were a couple errors caught.  Most notably, in the roboman avatar controller, the ```inAirTimer``` was using undefined variables.