### PR TITLE
Fix both butterfly examples #1286

### DIFF
--- a/Butterflies/CSharp/Resources/Components/Spawner.cs
+++ b/Butterflies/CSharp/Resources/Components/Spawner.cs
@@ -20,13 +20,13 @@ public class Spawner : CSComponent
 
             for (var i = 0; i < 10; i++)
                 createButterflyNode(new Vector2(mousePos.X, mousePos.Y));
-        }        
-		else if (input.GetMouseButtonDown(Constants.MOUSEB_RIGHT))
-		{
-			var mousePos = input.GetMousePosition();
+        }
+        else if (input.GetMouseButtonDown(Constants.MOUSEB_RIGHT))
+        {
+            var mousePos = input.GetMousePosition();
 
-			createButterflyParticle(new Vector2(mousePos.X, mousePos.Y));
-		}        
+            createButterflyParticle(new Vector2(mousePos.X, mousePos.Y));
+        }
 
     }
 
@@ -44,21 +44,21 @@ public class Spawner : CSComponent
 
     }
 
-	void createButterflyParticle(Vector2 pos)
-	{
-		//project mouse screen position to the world position
-		var screenPos = viewport.ScreenToWorldPoint((int) pos.X, (int) pos.Y, 0);
+    void createButterflyParticle(Vector2 pos)
+    {
+        //project mouse screen position to the world position
+        var screenPos = viewport.ScreenToWorldPoint((int) pos.X, (int) pos.Y, 0);
 
-		//create particle emitter
-		var emitter = Scene.CreateChild("ButterflyEmitter");
+        //create particle emitter
+        var emitter = Scene.CreateChild("ButterflyEmitter");
 
-		emitter.Position2D = new Vector2(screenPos.X, screenPos.Y);
+        emitter.Position2D = new Vector2(screenPos.X, screenPos.Y);
 
-		var pex = emitter.CreateComponent<ParticleEmitter2D>();
+        var pex = emitter.CreateComponent<ParticleEmitter2D>();
 
-		pex.SetEffect(GetSubsystem<ResourceCache>().GetResource<ParticleEffect2D> ("Particles/particle.pex"));
+        pex.SetEffect(GetSubsystem<ResourceCache>().GetResource<ParticleEffect2D> ("Particles/particle.pex"));
 
-	}
+    }
     Viewport viewport;
 
 

--- a/Butterflies/CSharp/Resources/Components/Spawner.cs
+++ b/Butterflies/CSharp/Resources/Components/Spawner.cs
@@ -21,6 +21,12 @@ public class Spawner : CSComponent
             for (var i = 0; i < 10; i++)
                 createButterflyNode(new Vector2(mousePos.X, mousePos.Y));
         }        
+		else if (input.GetMouseButtonDown(Constants.MOUSEB_RIGHT))
+		{
+			var mousePos = input.GetMousePosition();
+
+			createButterflyParticle(new Vector2(mousePos.X, mousePos.Y));
+		}        
 
     }
 
@@ -38,6 +44,21 @@ public class Spawner : CSComponent
 
     }
 
+	void createButterflyParticle(Vector2 pos)
+	{
+		//project mouse screen position to the world position
+		var screenPos = viewport.ScreenToWorldPoint((int) pos.X, (int) pos.Y, 0);
+
+		//create particle emitter
+		var emitter = Scene.CreateChild("ButterflyEmitter");
+
+		emitter.Position2D = new Vector2(screenPos.X, screenPos.Y);
+
+		var pex = emitter.CreateComponent<ParticleEmitter2D>();
+
+		pex.SetEffect(GetSubsystem<ResourceCache>().GetResource<ParticleEffect2D> ("Particles/particle.pex"));
+
+	}
     Viewport viewport;
 
 

--- a/Butterflies/JavaScript/Resources/Scripts/main.js
+++ b/Butterflies/JavaScript/Resources/Scripts/main.js
@@ -3,6 +3,9 @@
 // create a scene
 var scene = new Atomic.Scene();
 
+// assign scene into global so it's not GC'd
+Atomic.Player.currentScene = scene;
+
 // create an octree component
 scene.createComponent("Octree");
 


### PR DESCRIPTION
the JS butterfly example need the Scene object to be referenced so not to be GC'd. I attached it to the Atomic.Player, since that's where it would have been attached if it had loaded a scene.
The CS butterfly example did not have the butterfly emitter with the right mouse button, so that was added.