### PR TITLE
Fix for JS version of Basic2D example

### DIFF
--- a/Basic2D/JavaScript/Resources/Components/Spinner.js
+++ b/Basic2D/JavaScript/Resources/Components/Spinner.js
@@ -9,8 +9,7 @@ exports.component = function(self) {
     //update function calls each frame
     self.update = function(timeStep) {
         //roll a node
-        self.node.roll(timeStep * 100);
-
+        self.node.roll(timeStep * 100 * self.speed);
     };
 
 };


### PR DESCRIPTION
The Spinner exposes a "speed" field to the editor, but doesn't actually use it.  This makes the update method use the speed variable.

(This is my first Pull Request, hopefully I did it right)