### PR TITLE
fix case sensitive name in prefab

### DIFF
--- a/RoboMan3D/TypeScript/Resources/Prefabs/Robo_01.prefab
+++ b/RoboMan3D/TypeScript/Resources/Prefabs/Robo_01.prefab
@@ -191,7 +191,7 @@
 		<attribute name="AnimationResources" value="Animation;e30fa79a0b75b75cbe5b03a73baa28a5_Idle.ani;e30fa79a0b75b75cbe5b03a73baa28a5_Walk.ani;e30fa79a0b75b75cbe5b03a73baa28a5_Run.ani" />
 	</component>
 	<component type="JSComponent" id="2246">
-		<attribute name="ComponentFile" value="JSComponentFile;Components/RoboMan.js" />
+		<attribute name="ComponentFile" value="JSComponentFile;Components/Roboman.js" />
 	</component>
 	<component type="JSComponent" id="2008">
 		<attribute name="ComponentFile" value="JSComponentFile;Components/AvatarController.js" />


### PR DESCRIPTION
This PR fixes the name of a file, which is js generated from ts. the js file name that is generated is "roboman.js", though in the prefab definition it was entered as "RoboMan.js". On case sensitive platforms, this will not load the component.
